### PR TITLE
feat: generalize invmap to any variance via LiftIso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@
   and an `observedTrifunctorLaws` bundle for `map3`.
 * Add instances for `containers` (new dependency): `Map k`, `IntMap`, `Seq`,
   `ViewL`, `ViewR`, `Tree`, and `SCC`.
+* Generalize `invmap` to functors of any variance and add `mapIso`, both backed
+  by a new `LiftIso` class in `Kindly.Class` that reflects a `(->)` isomorphism
+  into an arbitrary category. `invmap` and `mapIso` now resolve for covariant
+  and contravariant functors, not just invariant ones, dropping the leg the
+  functor cannot use. The domain category is fixed by the functor argument, so
+  existing invariant call sites are unchanged. Add `liftIsoLaws` and
+  `mapIsoLaws` bundles to the laws sublibrary. `LiftIso` instances cover `(->)`,
+  `Op`, `Iso (->)`, and the Kleisli categories `Star f` and `Kleisli f` (for
+  `Monad f`). `Star Maybe` is the domain of a `Filterable` functor.
 
 ## 0.1.0.1 -- 2024-02-04
 

--- a/laws/Kindly/Functor/Laws.hs
+++ b/laws/Kindly/Functor/Laws.hs
@@ -14,7 +14,11 @@
 -- functor's /domain/ 'Category'. 'functorLaws' works at @('->')@ (covariant),
 -- 'contravariantFunctorLaws' at @'Op'@, 'invariantFunctorLaws' at
 -- @'Iso' ('->')@. 'bifunctorLaws' and 'profunctorLaws' also cover @'map2'@,
--- at the @('->')@ and 'Op' domains respectively.
+-- at the @('->')@ and 'Op' domains respectively. 'mapIsoLaws' checks
+-- @'Kindly.Functor.mapIso'@, which maps an isomorphism through a functor of any
+-- variance, so one bundle serves all three domains. 'liftIsoLaws' checks
+-- 'liftIso' itself at any target category, covering the 'LiftIso' instances no
+-- exported functor witnesses (e.g. @Star f@ and @Kleisli m@).
 --
 -- The bundles are separate functions because the comparison differs. Covariant
 -- functors compare directly with 'Eq'. Contravariant and invariant functors
@@ -33,6 +37,10 @@ module Kindly.Functor.Laws
 
     -- * Invariant functors
     invariantFunctorLaws,
+
+    -- * Isomorphism mapping (any variance)
+    liftIsoLaws,
+    mapIsoLaws,
 
     -- * Covariant bifunctors
     bifunctorLaws,
@@ -55,7 +63,8 @@ import Hedgehog (Gen, Property, forAll, forAllWith, property, (===))
 import Hedgehog.Classes (Laws (..))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import Kindly.Class (MapArg1, MapArg2, MapArg3, map1, map2, map3)
+import Kindly.Class (LiftIso, MapArg1, MapArg2, MapArg3, liftIso, map1, map2, map3)
+import Kindly.Functor (mapIso)
 import Prelude hiding (id, (.))
 
 --------------------------------------------------------------------------------
@@ -193,6 +202,93 @@ invariantComposition genF obs = property $ do
   let g = Iso (+ 1) (subtract 1) :: Iso (->) Int Int
       h = Iso (* 2) (`div` 2) :: Iso (->) Int Int
   obs (map1 (g . h) fa) a === obs (map1 g (map1 h fa)) a
+
+--------------------------------------------------------------------------------
+-- Isomorphism mapping (any variance)
+
+-- | The functor laws for 'liftIso', the identity-on-objects functor from the
+-- @'Iso' ('->')@ groupoid into a target category @cat@. Identity
+-- (@'liftIso' 'id' = 'id'@) and composition
+-- (@'liftIso' (i '.' j) = 'liftIso' i '.' 'liftIso' j@), with @'id'@ and @('.')@
+-- on the left in @'Iso' ('->')@ and on the right in @cat@. A @cat a b@ morphism
+-- is usually neither 'Eq' nor 'Show', so it is observed through @obs@ at the
+-- 'Int' witness. The target @cat@ is recovered from @obs@, so this bundle covers
+-- every 'LiftIso' instance, including those no exported functor witnesses.
+liftIsoLaws ::
+  forall cat r.
+  (LiftIso cat, Eq r, Show r) =>
+  (cat Int Int -> Int -> r) ->
+  Laws
+liftIsoLaws obs =
+  Laws
+    "liftIso"
+    [ ("Identity", liftIsoIdentity obs),
+      ("Composition", liftIsoComposition obs)
+    ]
+
+liftIsoIdentity ::
+  forall cat r.
+  (LiftIso cat, Eq r, Show r) =>
+  (cat Int Int -> Int -> r) ->
+  Property
+liftIsoIdentity obs = property $ do
+  a <- forAll genInt
+  obs (liftIso (id :: Iso (->) Int Int)) a === obs (id :: cat Int Int) a
+
+liftIsoComposition ::
+  forall cat r.
+  (LiftIso cat, Eq r, Show r) =>
+  (cat Int Int -> Int -> r) ->
+  Property
+liftIsoComposition obs = property $ do
+  a <- forAll genInt
+  let i = Iso (+ 1) (subtract 1) :: Iso (->) Int Int
+      j = Iso (* 2) (`div` 2) :: Iso (->) Int Int
+  obs (liftIso (i . j)) a === obs (liftIso i . liftIso j) a
+
+-- | The functor laws stated through @'mapIso'@, which maps a @('->')@
+-- isomorphism through a functor of /any/ variance. Identity
+-- (@'mapIso' 'id' = 'id'@) and composition
+-- (@'mapIso' (i '.' j) = 'mapIso' i '.' 'mapIso' j@), with @'id'@ and @('.')@ in
+-- the @'Iso' ('->')@ groupoid, observed through @obs@. The functor's domain
+-- category is recovered from @f@, so one bundle covers covariant, contravariant,
+-- and invariant functors.
+mapIsoLaws ::
+  forall cat f r.
+  (MapArg1 cat f, LiftIso cat, Eq r, Show r) =>
+  Gen (f Int) ->
+  (f Int -> Int -> r) ->
+  Laws
+mapIsoLaws genF obs =
+  Laws
+    "mapIso"
+    [ ("Identity", mapIsoIdentity genF obs),
+      ("Composition", mapIsoComposition genF obs)
+    ]
+
+mapIsoIdentity ::
+  forall cat f r.
+  (MapArg1 cat f, LiftIso cat, Eq r, Show r) =>
+  Gen (f Int) ->
+  (f Int -> Int -> r) ->
+  Property
+mapIsoIdentity genF obs = property $ do
+  fa <- forAllWith (const "<opaque>") genF
+  a <- forAll genInt
+  obs (mapIso (id :: Iso (->) Int Int) fa) a === obs fa a
+
+mapIsoComposition ::
+  forall cat f r.
+  (MapArg1 cat f, LiftIso cat, Eq r, Show r) =>
+  Gen (f Int) ->
+  (f Int -> Int -> r) ->
+  Property
+mapIsoComposition genF obs = property $ do
+  fa <- forAllWith (const "<opaque>") genF
+  a <- forAll genInt
+  let i = Iso (+ 1) (subtract 1) :: Iso (->) Int Int
+      j = Iso (* 2) (`div` 2) :: Iso (->) Int Int
+  obs (mapIso (i . j) fa) a === obs (mapIso i (mapIso j fa)) a
 
 --------------------------------------------------------------------------------
 -- Covariant bifunctor

--- a/src/Kindly/Class.hs
+++ b/src/Kindly/Class.hs
@@ -4,8 +4,12 @@ module Kindly.Class where
 
 --------------------------------------------------------------------------------
 
+import Control.Arrow (Kleisli (..))
 import Control.Category
+import Data.Functor.Contravariant (Op (..))
+import Data.Isomorphism (Iso (..))
 import Data.Kind (Constraint)
+import Data.Profunctor (Star (..))
 import Data.Semigroupoid (Semigroupoid (..))
 #if MIN_VERSION_base(4,17,0)
 -- On GHC 9.4+ (@base >= 4.17@) @~@ is an ordinary type operator rather than
@@ -13,7 +17,7 @@ import Data.Semigroupoid (Semigroupoid (..))
 -- Earlier GHCs still treat @~@ as built-in syntax and do not export it.
 import Data.Type.Equality (type (~))
 #endif
-import GHC.Base (Type)
+import GHC.Base (Monad, Type, pure)
 
 --------------------------------------------------------------------------------
 
@@ -97,3 +101,59 @@ instance
 instance
   (CategoricalFunctor p, Cod p ~ (cat2 ~> cat3 ~> (->)), cat1 ~ Dom p, forall x. MapArg2 cat2 cat3 (p x)) =>
   MapArg3 cat1 cat2 cat3 p
+
+--------------------------------------------------------------------------------
+
+-- | Lift a @('->')@ isomorphism into an arbitrary category @cat@. This is the
+-- identity-on-objects functor from the @('->')@ core groupoid (embodied by
+-- @'Iso' ('->')@) into @cat@. Objects stay put, and an isomorphism becomes a
+-- @cat@ morphism that keeps whichever leg @cat@ can use and discards the other.
+--
+-- Every category admits this functor, which is what lets a 'CategoricalFunctor'
+-- of /any/ variance map an isomorphism, whether its domain is @('->')@
+-- (covariant), 'Op' (contravariant), or @'Iso' ('->')@ (invariant). See
+-- 'Kindly.Functor.mapIso'.
+--
+-- 'liftIso' fixes its source to @'Iso' ('->')@, so @a@ and @b@ are 'Type' and
+-- the kind is @'Cat' 'Type'@. Supporting rank-2 functors (whose objects are type
+-- constructors) needs more than @PolyKinds@. There the universally available
+-- isos are natural isomorphisms, @'Iso' ((->) '~>' (->))@, not @'Iso' ('->')@,
+-- so the source groupoid has to be abstracted too, e.g. a second parameter
+-- @LiftIso src cat@ carrying the core groupoid at that kind.
+--
+-- === Laws
+--
+-- [Identity]    @'liftIso' 'id' == 'id'@
+-- [Composition] @'liftIso' (i '.' j) == 'liftIso' i '.' 'liftIso' j@
+type LiftIso :: Cat Type -> Constraint
+class (Category cat) => LiftIso cat where
+  liftIso :: Iso (->) a b -> cat a b
+
+-- | A covariant @('->')@ functor keeps the forward leg.
+instance LiftIso (->) where
+  liftIso :: Iso (->) a b -> a -> b
+  liftIso = embed
+
+-- | A contravariant 'Op' functor keeps the backward leg.
+instance LiftIso Op where
+  liftIso :: Iso (->) a b -> Op a b
+  liftIso i = Op (project i)
+
+-- | An invariant @'Iso' ('->')@ functor keeps both legs. The lift is the identity.
+instance LiftIso (Iso (->)) where
+  liftIso :: Iso (->) a b -> Iso (->) a b
+  liftIso = id
+
+-- | A @'Star' f@ Kleisli arrow keeps the forward leg, returning it in @f@ via
+-- 'pure'. Needs @'Monad' f@, matching its @'Category' ('Star' f)@ instance.
+-- @Star Maybe@ is the domain the library uses for filtering (@Filterable@)
+-- functors.
+instance (Monad f) => LiftIso (Star f) where
+  liftIso :: Iso (->) a b -> Star f a b
+  liftIso i = Star (pure . embed i)
+
+-- | A @'Kleisli' m@ arrow is @Star@ by another name (base's copy of the same
+-- @a -> m b@ type), so its lift is identical.
+instance (Monad m) => LiftIso (Kleisli m) where
+  liftIso :: Iso (->) a b -> Kleisli m a b
+  liftIso i = Kleisli (pure . embed i)

--- a/src/Kindly/Functor.hs
+++ b/src/Kindly/Functor.hs
@@ -6,6 +6,7 @@ module Kindly.Functor
   ( Functor,
     fmap,
     contramap,
+    mapIso,
     invmap,
     Filterable,
     mapMaybe,
@@ -126,13 +127,24 @@ fmap = map1
 contramap :: (Functor Op p) => (a -> b) -> p b -> p a
 contramap = fmap . Op
 
--- | A specialization of 'fmap' for invariant functors as defined
--- in 'Data.Functor.Invariant.'
+-- | Map a @('->')@ isomorphism through a 'Functor' of /any/ variance. A functor
+-- can always transport an isomorphism. 'liftIso' reflects the iso into the
+-- functor's domain category @cat@, dropping whichever leg @cat@ ignores (the
+-- backward leg for a covariant @('->')@ functor, the forward leg for a
+-- contravariant 'Op' one, neither for an invariant @'Iso' ('->')@ one).
 --
--- TODO: Do we keep this around? This is nice to have so that library
--- users don't have to manually pack functions in t'Iso'.
-invmap :: (Functor (Iso (->)) f) => (a -> b) -> (b -> a) -> f a -> f b
-invmap f g = fmap (Iso f g)
+-- 'mapIso' generalizes 'invmap'. @'invmap' f g = 'mapIso' ('Iso' f g)@.
+mapIso :: (Functor cat f, LiftIso cat) => Iso (->) a b -> f a -> f b
+mapIso i = fmap (liftIso i)
+
+-- | Map an isomorphism through a 'Functor' of /any/ variance, generalizing the
+-- invariant-only version. The two legs are packed into an @'Iso' ('->')@ and
+-- mapped with 'mapIso', so 'invmap' now resolves for covariant and
+-- contravariant functors too, not just invariant ones. The domain category is
+-- fixed by the functor argument, so existing invariant call sites are
+-- unaffected.
+invmap :: (Functor cat f, LiftIso cat) => (a -> b) -> (b -> a) -> f a -> f b
+invmap f g = mapIso (Iso f g)
 
 -- TODO: 'Filterable' is currently unusable due to fundeps. This can
 -- be fixed by making it @FunctorOf (Hask.Star Maybe) (->) p@, but I

--- a/test/LawsSpec.hs
+++ b/test/LawsSpec.hs
@@ -39,6 +39,7 @@ import Data.Functor.Sum (Sum (..))
 import Data.Functor.These (These1 (..))
 import Data.Graph (SCC (..))
 import Data.IntMap qualified as IntMap
+import Data.Isomorphism (Iso (..))
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as Map
 import Data.Monoid (Endo (..))
@@ -69,6 +70,8 @@ import Kindly.Functor.Laws
     contravariantFunctorLaws,
     functorLaws,
     invariantFunctorLaws,
+    liftIsoLaws,
+    mapIsoLaws,
     observedBifunctorLaws,
     observedTrifunctorLaws,
     profunctorLaws,
@@ -92,6 +95,13 @@ genNonEmpty = Gen.nonEmpty (Range.linear 1 4)
 
 genIdentity :: Gen a -> Gen (Identity a)
 genIdentity g = Identity <$> g
+
+obsIdentity :: Identity Int -> Int -> Int
+obsIdentity (Identity x) _ = x
+
+-- Observe an @Iso (->)@ morphism by running both legs.
+obsIsoCat :: Iso (->) Int Int -> Int -> (Int, Int)
+obsIsoCat i a = (embed i a, project i a)
 
 -- Structural and generic-representation functors.
 
@@ -461,6 +471,16 @@ tests =
           labeled "Equivalence" (contravariantFunctorLaws genEquivalence obsEquivalence),
           labeled "Op Int" (contravariantFunctorLaws genOp obsOp),
           labeled "Endo" (invariantFunctorLaws genEndo obsEndo),
+          -- mapIso across all three variances (isomorphism mapping).
+          labeled "mapIso Identity" (mapIsoLaws (genIdentity genInt) obsIdentity),
+          labeled "mapIso Predicate" (mapIsoLaws genPredicate obsPredicate),
+          labeled "mapIso Endo" (mapIsoLaws genEndo obsEndo),
+          -- liftIso: the core-groupoid inclusion at each target category.
+          labeled "liftIso (->)" (liftIsoLaws obsFn),
+          labeled "liftIso Op" (liftIsoLaws obsOp),
+          labeled "liftIso Iso (->)" (liftIsoLaws obsIsoCat),
+          labeled "liftIso Star Maybe" (liftIsoLaws obsStar),
+          labeled "liftIso Kleisli Maybe" (liftIsoLaws obsKleisli),
           -- Covariant bifunctors (map2).
           labeled "(,)" (bifunctorLaws genPairT),
           labeled "Either" (bifunctorLaws genEitherT),

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -13,8 +13,10 @@ import Control.Arrow (Kleisli (..))
 import Control.Monad (when)
 import Data.Functor.Contravariant (Op (..), Predicate (..))
 import Data.Functor.Identity (Identity (..))
+import Data.Isomorphism (Iso (Iso))
 import Data.Maybe (maybeToList)
 import Data.Monoid (Endo (..))
+import Data.Profunctor (Star (..))
 import Kindly qualified as UUT
 import LawsSpec qualified
 import Rank2LawsSpec qualified
@@ -50,6 +52,29 @@ exampleSpec = do
   describe "invmap" $ do
     it "works invariantly (Endo)" $ do
       appEndo (UUT.invmap (+ 1) (subtract 1) (Endo (* 2))) (5 :: Int) `shouldBe` 9
+    it "works covariantly (Identity), dropping the backward leg" $ do
+      UUT.invmap (show :: Int -> String) (read :: String -> Int) (Identity (5 :: Int)) `shouldBe` Identity "5"
+    it "works contravariantly (Predicate), dropping the forward leg" $ do
+      getPredicate (UUT.invmap (show :: Int -> String) (read :: String -> Int) (Predicate even)) "4" `shouldBe` True
+      getPredicate (UUT.invmap (show :: Int -> String) (read :: String -> Int) (Predicate even)) "5" `shouldBe` False
+
+  describe "mapIso" $ do
+    it "maps an iso through a covariant functor (Identity)" $ do
+      UUT.mapIso (Iso (show :: Int -> String) (read :: String -> Int)) (Identity (5 :: Int)) `shouldBe` Identity "5"
+    it "maps an iso through a contravariant functor (Predicate)" $ do
+      getPredicate (UUT.mapIso (Iso (show :: Int -> String) (read :: String -> Int)) (Predicate even)) "4" `shouldBe` True
+    it "maps an iso through an invariant functor (Endo)" $ do
+      appEndo (UUT.mapIso (Iso (+ 1) (subtract 1)) (Endo (* 2))) (5 :: Int) `shouldBe` 9
+
+  describe "liftIso (Star)" $ do
+    it "wraps the forward leg in pure, dropping the backward leg" $ do
+      runStar (UUT.liftIso (Iso (show :: Int -> String) (read :: String -> Int)) :: Star Maybe Int String) 5 `shouldBe` Just "5"
+    it "sends an identity iso to the Kleisli identity" $ do
+      runStar (UUT.liftIso (Iso id id :: Iso (->) Int Int) :: Star Maybe Int Int) 5 `shouldBe` Just 5
+
+  describe "liftIso (Kleisli)" $ do
+    it "wraps the forward leg in pure, dropping the backward leg" $ do
+      runKleisli (UUT.liftIso (Iso (show :: Int -> String) (read :: String -> Int)) :: Kleisli Maybe Int String) 5 `shouldBe` Just "5"
 
   describe "lmap" $ do
     it "works covariantly" $ do


### PR DESCRIPTION
`invmap` previously only resolved for invariant functors, because its constraint hardcoded the invariant category `Iso (->)`. Mapping an isomorphism through a functor is fine at any variance, so this generalizes it. A functor drops whichever leg its domain category cannot use. The backward leg for a covariant functor, the forward leg for a contravariant one, neither for an invariant one.

The generalization is backed by a small `LiftIso` class that reflects a Hask isomorphism into an arbitrary category:

```haskell
class Category cat => LiftIso cat where
  liftIso :: Iso (->) a b -> cat a b
```

`mapIso` maps an iso through any functor via `liftIso`, and `invmap` is now defined as `invmap f g = mapIso (Iso f g)`. The domain category is fixed by the functor argument through the `MapArg1` fundep, so no new ambiguity is introduced.