### PR TITLE
feat: add bimapIso and trimapIso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,14 @@
   `mapIsoLaws` bundles to the laws sublibrary. `LiftIso` instances cover `(->)`,
   `Op`, `Iso (->)`, and the Kleisli categories `Star f` and `Kleisli f` (for
   `Monad f`). `Star Maybe` is the domain of a `Filterable` functor.
+* Add `bimapIso` and `trimapIso`, the bifunctor and trifunctor analogs of
+  `mapIso`. Each maps a `(->)` isomorphism through every position of a
+  bifunctor/trifunctor regardless of that position's variance, taking one `Iso`
+  per position and reflecting it into that position's category with `liftIso`.
+  Add `bimapIsoLaws` and `trimapIsoLaws` bundles to the laws sublibrary.
+  Re-export `Iso` from `Kindly.Functor`, `Kindly.Bifunctor`, `Kindly.Trifunctor`,
+  and `Kindly` so callers of `mapIso`/`bimapIso`/`trimapIso` can build
+  isomorphisms without importing `Data.Isomorphism` directly.
 
 ## 0.1.0.1 -- 2024-02-04
 

--- a/laws/Kindly/Functor/Laws.hs
+++ b/laws/Kindly/Functor/Laws.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ImpredicativeTypes #-}
+
 -- | @hedgehog-classes@ 'Laws' for this library's category-polymorphic functor
 -- classes. A consumer can law-test their own 'CategoricalFunctor', 'MapArg1',
 -- and 'MapArg2' instances the way they test 'Functor' or 'Monoid'.
@@ -68,10 +70,10 @@ import Hedgehog (Gen, Property, forAll, forAllWith, property, (===))
 import Hedgehog.Classes (Laws (..))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
-import Kindly.Bifunctor (bimapIso)
+import Kindly.Bifunctor (Bifunctor, bimapIso)
 import Kindly.Class (LiftIso, MapArg1, MapArg2, MapArg3, liftIso, map1, map2, map3)
 import Kindly.Functor (mapIso)
-import Kindly.Trifunctor (trimapIso)
+import Kindly.Trifunctor (Trifunctor, trimapIso)
 import Prelude hiding (id, (.))
 
 --------------------------------------------------------------------------------
@@ -395,13 +397,7 @@ observedBifunctorComposition genP obs = property $ do
 -- every combination of variances.
 bimapIsoLaws ::
   forall cat1 cat2 p r.
-  ( MapArg2 cat1 cat2 p,
-    forall x. MapArg1 cat2 (p x),
-    LiftIso cat1,
-    LiftIso cat2,
-    Eq r,
-    Show r
-  ) =>
+  (Bifunctor cat1 cat2 p, LiftIso cat1, LiftIso cat2, Eq r, Show r) =>
   Gen (p Int Int) ->
   (p Int Int -> Int -> r) ->
   Laws
@@ -414,13 +410,7 @@ bimapIsoLaws genP obs =
 
 bimapIsoIdentity ::
   forall cat1 cat2 p r.
-  ( MapArg2 cat1 cat2 p,
-    forall x. MapArg1 cat2 (p x),
-    LiftIso cat1,
-    LiftIso cat2,
-    Eq r,
-    Show r
-  ) =>
+  (Bifunctor cat1 cat2 p, LiftIso cat1, LiftIso cat2, Eq r, Show r) =>
   Gen (p Int Int) ->
   (p Int Int -> Int -> r) ->
   Property
@@ -431,13 +421,7 @@ bimapIsoIdentity genP obs = property $ do
 
 bimapIsoComposition ::
   forall cat1 cat2 p r.
-  ( MapArg2 cat1 cat2 p,
-    forall x. MapArg1 cat2 (p x),
-    LiftIso cat1,
-    LiftIso cat2,
-    Eq r,
-    Show r
-  ) =>
+  (Bifunctor cat1 cat2 p, LiftIso cat1, LiftIso cat2, Eq r, Show r) =>
   Gen (p Int Int) ->
   (p Int Int -> Int -> r) ->
   Property
@@ -505,15 +489,7 @@ observedTrifunctorComposition genP obs = property $ do
 -- recovered from @p@, so one bundle covers every combination of variances.
 trimapIsoLaws ::
   forall cat1 cat2 cat3 p r.
-  ( MapArg3 cat3 cat2 cat1 p,
-    forall x. MapArg2 cat2 cat1 (p x),
-    forall x y. MapArg1 cat1 (p x y),
-    LiftIso cat1,
-    LiftIso cat2,
-    LiftIso cat3,
-    Eq r,
-    Show r
-  ) =>
+  (Trifunctor cat1 cat2 cat3 p, LiftIso cat1, LiftIso cat2, LiftIso cat3, Eq r, Show r) =>
   Gen (p Int Int Int) ->
   (p Int Int Int -> Int -> r) ->
   Laws
@@ -526,15 +502,7 @@ trimapIsoLaws genP obs =
 
 trimapIsoIdentity ::
   forall cat1 cat2 cat3 p r.
-  ( MapArg3 cat3 cat2 cat1 p,
-    forall x. MapArg2 cat2 cat1 (p x),
-    forall x y. MapArg1 cat1 (p x y),
-    LiftIso cat1,
-    LiftIso cat2,
-    LiftIso cat3,
-    Eq r,
-    Show r
-  ) =>
+  (Trifunctor cat1 cat2 cat3 p, LiftIso cat1, LiftIso cat2, LiftIso cat3, Eq r, Show r) =>
   Gen (p Int Int Int) ->
   (p Int Int Int -> Int -> r) ->
   Property
@@ -545,15 +513,7 @@ trimapIsoIdentity genP obs = property $ do
 
 trimapIsoComposition ::
   forall cat1 cat2 cat3 p r.
-  ( MapArg3 cat3 cat2 cat1 p,
-    forall x. MapArg2 cat2 cat1 (p x),
-    forall x y. MapArg1 cat1 (p x y),
-    LiftIso cat1,
-    LiftIso cat2,
-    LiftIso cat3,
-    Eq r,
-    Show r
-  ) =>
+  (Trifunctor cat1 cat2 cat3 p, LiftIso cat1, LiftIso cat2, LiftIso cat3, Eq r, Show r) =>
   Gen (p Int Int Int) ->
   (p Int Int Int -> Int -> r) ->
   Property

--- a/laws/Kindly/Functor/Laws.hs
+++ b/laws/Kindly/Functor/Laws.hs
@@ -16,9 +16,12 @@
 -- @'Iso' ('->')@. 'bifunctorLaws' and 'profunctorLaws' also cover @'map2'@,
 -- at the @('->')@ and 'Op' domains respectively. 'mapIsoLaws' checks
 -- @'Kindly.Functor.mapIso'@, which maps an isomorphism through a functor of any
--- variance, so one bundle serves all three domains. 'liftIsoLaws' checks
--- 'liftIso' itself at any target category, covering the 'LiftIso' instances no
--- exported functor witnesses (e.g. @Star f@ and @Kleisli m@).
+-- variance, so one bundle serves all three domains. 'bimapIsoLaws' and
+-- 'trimapIsoLaws' do the same for @'Kindly.Bifunctor.bimapIso'@ and
+-- @'Kindly.Trifunctor.trimapIso'@, checking functoriality in every 'Iso'
+-- position. 'liftIsoLaws' checks 'liftIso' itself at any target category,
+-- covering the 'LiftIso' instances no exported functor witnesses (e.g.
+-- @Star f@ and @Kleisli m@).
 --
 -- The bundles are separate functions because the comparison differs. Covariant
 -- functors compare directly with 'Eq'. Contravariant and invariant functors
@@ -45,12 +48,14 @@ module Kindly.Functor.Laws
     -- * Covariant bifunctors
     bifunctorLaws,
     observedBifunctorLaws,
+    bimapIsoLaws,
 
     -- * Profunctors
     profunctorLaws,
 
     -- * Trifunctors
     observedTrifunctorLaws,
+    trimapIsoLaws,
   )
 where
 
@@ -63,8 +68,10 @@ import Hedgehog (Gen, Property, forAll, forAllWith, property, (===))
 import Hedgehog.Classes (Laws (..))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
+import Kindly.Bifunctor (bimapIso)
 import Kindly.Class (LiftIso, MapArg1, MapArg2, MapArg3, liftIso, map1, map2, map3)
 import Kindly.Functor (mapIso)
+import Kindly.Trifunctor (trimapIso)
 import Prelude hiding (id, (.))
 
 --------------------------------------------------------------------------------
@@ -377,6 +384,73 @@ observedBifunctorComposition genP obs = property $ do
   obs (map2 (g . h) p) a === obs (map2 g (map2 h p)) a
 
 --------------------------------------------------------------------------------
+-- Bifunctor isomorphism mapping (any variance)
+
+-- | The functor laws stated through @'Kindly.Bifunctor.bimapIso'@, which maps a
+-- @('->')@ isomorphism through each position of a bifunctor of /any/ variance.
+-- Identity (@'bimapIso' 'id' 'id' = 'id'@) and composition
+-- (@'bimapIso' (i '.' i') (j '.' j') = 'bimapIso' i j '.' 'bimapIso' i' j'@),
+-- with @'id'@ and @('.')@ in the @'Iso' ('->')@ groupoid, observed through
+-- @obs@. Each position's category is recovered from @p@, so one bundle covers
+-- every combination of variances.
+bimapIsoLaws ::
+  forall cat1 cat2 p r.
+  ( MapArg2 cat1 cat2 p,
+    forall x. MapArg1 cat2 (p x),
+    LiftIso cat1,
+    LiftIso cat2,
+    Eq r,
+    Show r
+  ) =>
+  Gen (p Int Int) ->
+  (p Int Int -> Int -> r) ->
+  Laws
+bimapIsoLaws genP obs =
+  Laws
+    "bimapIso"
+    [ ("Identity", bimapIsoIdentity genP obs),
+      ("Composition", bimapIsoComposition genP obs)
+    ]
+
+bimapIsoIdentity ::
+  forall cat1 cat2 p r.
+  ( MapArg2 cat1 cat2 p,
+    forall x. MapArg1 cat2 (p x),
+    LiftIso cat1,
+    LiftIso cat2,
+    Eq r,
+    Show r
+  ) =>
+  Gen (p Int Int) ->
+  (p Int Int -> Int -> r) ->
+  Property
+bimapIsoIdentity genP obs = property $ do
+  p <- forAllWith (const "<opaque>") genP
+  a <- forAll genInt
+  obs (bimapIso (id :: Iso (->) Int Int) (id :: Iso (->) Int Int) p) a === obs p a
+
+bimapIsoComposition ::
+  forall cat1 cat2 p r.
+  ( MapArg2 cat1 cat2 p,
+    forall x. MapArg1 cat2 (p x),
+    LiftIso cat1,
+    LiftIso cat2,
+    Eq r,
+    Show r
+  ) =>
+  Gen (p Int Int) ->
+  (p Int Int -> Int -> r) ->
+  Property
+bimapIsoComposition genP obs = property $ do
+  p <- forAllWith (const "<opaque>") genP
+  a <- forAll genInt
+  let i1 = Iso (+ 1) (subtract 1) :: Iso (->) Int Int
+      i2 = Iso (* 2) (`div` 2) :: Iso (->) Int Int
+      j1 = Iso (+ 3) (subtract 3) :: Iso (->) Int Int
+      j2 = Iso (* 5) (`div` 5) :: Iso (->) Int Int
+  obs (bimapIso (i1 . i2) (j1 . j2) p) a === obs (bimapIso i1 j1 (bimapIso i2 j2 p)) a
+
+--------------------------------------------------------------------------------
 -- Trifunctor
 
 -- | The functor laws for a covariant @'map3'@, observed through @obs@ so the
@@ -418,6 +492,82 @@ observedTrifunctorComposition genP obs = property $ do
   let g = (+ 1) :: Int -> Int
       h = (* 2) :: Int -> Int
   obs (map3 (g . h) p) a === obs (map3 g (map3 h p)) a
+
+--------------------------------------------------------------------------------
+-- Trifunctor isomorphism mapping (any variance)
+
+-- | The functor laws stated through @'Kindly.Trifunctor.trimapIso'@, which maps
+-- a @('->')@ isomorphism through each position of a trifunctor of /any/
+-- variance. Identity (@'trimapIso' 'id' 'id' 'id' = 'id'@) and composition
+-- (@'trimapIso' (i '.' i') (j '.' j') (k '.' k') =
+-- 'trimapIso' i j k '.' 'trimapIso' i' j' k'@), with @'id'@ and @('.')@ in the
+-- @'Iso' ('->')@ groupoid, observed through @obs@. Each position's category is
+-- recovered from @p@, so one bundle covers every combination of variances.
+trimapIsoLaws ::
+  forall cat1 cat2 cat3 p r.
+  ( MapArg3 cat3 cat2 cat1 p,
+    forall x. MapArg2 cat2 cat1 (p x),
+    forall x y. MapArg1 cat1 (p x y),
+    LiftIso cat1,
+    LiftIso cat2,
+    LiftIso cat3,
+    Eq r,
+    Show r
+  ) =>
+  Gen (p Int Int Int) ->
+  (p Int Int Int -> Int -> r) ->
+  Laws
+trimapIsoLaws genP obs =
+  Laws
+    "trimapIso"
+    [ ("Identity", trimapIsoIdentity genP obs),
+      ("Composition", trimapIsoComposition genP obs)
+    ]
+
+trimapIsoIdentity ::
+  forall cat1 cat2 cat3 p r.
+  ( MapArg3 cat3 cat2 cat1 p,
+    forall x. MapArg2 cat2 cat1 (p x),
+    forall x y. MapArg1 cat1 (p x y),
+    LiftIso cat1,
+    LiftIso cat2,
+    LiftIso cat3,
+    Eq r,
+    Show r
+  ) =>
+  Gen (p Int Int Int) ->
+  (p Int Int Int -> Int -> r) ->
+  Property
+trimapIsoIdentity genP obs = property $ do
+  p <- forAllWith (const "<opaque>") genP
+  a <- forAll genInt
+  obs (trimapIso (id :: Iso (->) Int Int) (id :: Iso (->) Int Int) (id :: Iso (->) Int Int) p) a === obs p a
+
+trimapIsoComposition ::
+  forall cat1 cat2 cat3 p r.
+  ( MapArg3 cat3 cat2 cat1 p,
+    forall x. MapArg2 cat2 cat1 (p x),
+    forall x y. MapArg1 cat1 (p x y),
+    LiftIso cat1,
+    LiftIso cat2,
+    LiftIso cat3,
+    Eq r,
+    Show r
+  ) =>
+  Gen (p Int Int Int) ->
+  (p Int Int Int -> Int -> r) ->
+  Property
+trimapIsoComposition genP obs = property $ do
+  p <- forAllWith (const "<opaque>") genP
+  a <- forAll genInt
+  let i1 = Iso (+ 1) (subtract 1) :: Iso (->) Int Int
+      i2 = Iso (* 2) (`div` 2) :: Iso (->) Int Int
+      j1 = Iso (+ 3) (subtract 3) :: Iso (->) Int Int
+      j2 = Iso (* 5) (`div` 5) :: Iso (->) Int Int
+      k1 = Iso (+ 7) (subtract 7) :: Iso (->) Int Int
+      k2 = Iso (* 11) (`div` 11) :: Iso (->) Int Int
+  obs (trimapIso (i1 . i2) (j1 . j2) (k1 . k2) p) a
+    === obs (trimapIso i1 j1 k1 (trimapIso i2 j2 k2 p)) a
 
 --------------------------------------------------------------------------------
 -- Profunctor

--- a/src/Kindly/Bifunctor.hs
+++ b/src/Kindly/Bifunctor.hs
@@ -5,6 +5,8 @@
 module Kindly.Bifunctor
   ( Bifunctor,
     bimap,
+    bimapIso,
+    Iso (..),
     lmap,
     rmap,
   )
@@ -30,6 +32,7 @@ import Data.Functor qualified as Hask
 import Data.Functor.Const (Const)
 import Data.Functor.Constant (Constant (..))
 import Data.Functor.Contravariant (Op (..))
+import Data.Isomorphism (Iso (..))
 import Data.Kind (Constraint, Type)
 import Data.Profunctor qualified as Hask
 import Data.Profunctor.Cayley qualified as Hask
@@ -59,6 +62,22 @@ type Bifunctor cat1 cat2 p = (MapArg2 cat1 cat2 p, forall x. MapArg1 cat2 (p x))
 -- function @p a b -> p a' b'@.
 bimap :: forall cat1 cat2 p. (Bifunctor cat1 cat2 p) => forall a b a' b'. (a `cat1` a') -> (b `cat2` b') -> p a b -> p a' b'
 bimap f g = map2 f . map1 g
+
+-- | Map a @('->')@ isomorphism through each position of a 'Bifunctor',
+-- regardless of that position's variance. A bifunctor can always transport an
+-- isomorphism in either argument, so 'liftIso' reflects each iso into that
+-- position's category and drops whichever leg the category ignores. The first
+-- 'Iso' maps the first type argument, the second the second.
+--
+-- 'bimapIso' is to 'bimap' what 'Kindly.Functor.mapIso' is to
+-- 'Kindly.Functor.fmap'.
+bimapIso ::
+  (Bifunctor cat1 cat2 p, LiftIso cat1, LiftIso cat2) =>
+  Iso (->) a a' ->
+  Iso (->) b b' ->
+  p a b ->
+  p a' b'
+bimapIso i j = bimap (liftIso i) (liftIso j)
 
 -- | Lift a morphism @cat1 a b@ into a function @p a x -> p b x@.
 lmap :: (Category cat2, Bifunctor cat1 cat2 p) => (a `cat1` b) -> p a x -> p b x

--- a/src/Kindly/Functor.hs
+++ b/src/Kindly/Functor.hs
@@ -8,6 +8,7 @@ module Kindly.Functor
     contramap,
     mapIso,
     invmap,
+    Iso (..),
     Filterable,
     mapMaybe,
     catMaybes,

--- a/src/Kindly/Trifunctor.hs
+++ b/src/Kindly/Trifunctor.hs
@@ -5,6 +5,8 @@
 module Kindly.Trifunctor
   ( Trifunctor,
     trimap,
+    trimapIso,
+    Iso (..),
   )
 where
 
@@ -12,6 +14,7 @@ where
 
 import Control.Category
 import Data.Functor.Contravariant (Op)
+import Data.Isomorphism (Iso (..))
 import Data.Kind (Constraint, Type)
 import Data.Profunctor (Forget (..))
 import GHC.Generics (K1 (..))
@@ -28,6 +31,24 @@ type Trifunctor cat1 cat2 cat3 p = (MapArg3 cat3 cat2 cat1 p, forall x. MapArg2 
 -- | Lift a morphism @cat1 a a'@, a morphism @cat2 b b'@, and a morphism @cat3 c c'@ into a -- function @p a b c -> p a' b' c'@.
 trimap :: forall cat1 cat2 cat3 p. (Trifunctor cat1 cat2 cat3 p) => forall a b c a' b' c'. (a `cat3` a') -> (b `cat2` b') -> (c `cat1` c') -> p a b c -> p a' b' c'
 trimap f g h = map3 f . map2 @_ @cat1 g . map1 h
+
+-- | Map a @('->')@ isomorphism through each position of a 'Trifunctor',
+-- regardless of that position's variance. A trifunctor can always transport an
+-- isomorphism in any argument, so 'liftIso' reflects each iso into that
+-- position's category and drops whichever leg the category ignores. The isos
+-- map the type arguments left-to-right: the first maps the first argument, the
+-- second the second, the third the third.
+--
+-- 'trimapIso' is to 'trimap' what 'Kindly.Functor.mapIso' is to
+-- 'Kindly.Functor.fmap'.
+trimapIso ::
+  (Trifunctor cat1 cat2 cat3 p, LiftIso cat1, LiftIso cat2, LiftIso cat3) =>
+  Iso (->) a a' ->
+  Iso (->) b b' ->
+  Iso (->) c c' ->
+  p a b c ->
+  p a' b' c'
+trimapIso i j k = trimap (liftIso i) (liftIso j) (liftIso k)
 
 --------------------------------------------------------------------------------
 

--- a/test/LawsSpec.hs
+++ b/test/LawsSpec.hs
@@ -67,6 +67,7 @@ import Hedgehog.Range qualified as Range
 import Kindly ()
 import Kindly.Functor.Laws
   ( bifunctorLaws,
+    bimapIsoLaws,
     contravariantFunctorLaws,
     functorLaws,
     invariantFunctorLaws,
@@ -75,6 +76,7 @@ import Kindly.Functor.Laws
     observedBifunctorLaws,
     observedTrifunctorLaws,
     profunctorLaws,
+    trimapIsoLaws,
   )
 import Prelude
 
@@ -475,6 +477,14 @@ tests =
           labeled "mapIso Identity" (mapIsoLaws (genIdentity genInt) obsIdentity),
           labeled "mapIso Predicate" (mapIsoLaws genPredicate obsPredicate),
           labeled "mapIso Endo" (mapIsoLaws genEndo obsEndo),
+          -- bimapIso: isomorphism mapping through a bifunctor's positions.
+          labeled "bimapIso (,)" (bimapIsoLaws (genPairT genInt genInt) (\p _ -> p)),
+          labeled "bimapIso Op" (bimapIsoLaws genOp obsOp),
+          labeled "bimapIso Dual (->)" (bimapIsoLaws genDual obsDual),
+          -- trimapIso: isomorphism mapping through a trifunctor's positions.
+          labeled "trimapIso (,,)" (trimapIsoLaws genTriple obsTriple),
+          labeled "trimapIso Forget" (trimapIsoLaws genForgetT obsForgetT),
+          labeled "trimapIso K1" (trimapIsoLaws genK1 obsK1),
           -- liftIso: the core-groupoid inclusion at each target category.
           labeled "liftIso (->)" (liftIsoLaws obsFn),
           labeled "liftIso Op" (liftIsoLaws obsOp),


### PR DESCRIPTION
Adds `bimapIso` and `trimapIso`, the bifunctor and trifunctor analogs of `mapIso`. Each transports a `(->)` isomorphism through every position of a bifunctor/trifunctor regardless of that position's variance, taking one `Iso` per position and reflecting it into that position's category with `liftIso`.

Also in this PR:

- `bimapIsoLaws` and `trimapIsoLaws` bundles in the laws sublibrary, wired into the test suite across covariant and contravariant witnesses (`(,)`, `Op`, `Dual` for bimap; `(,,)`, `Forget`, `K1` for trimap).
- Re-export `Iso` from `Kindly.Functor`, `Kindly.Bifunctor`, `Kindly.Trifunctor`, and `Kindly` so callers of `mapIso`/`bimapIso`/`trimapIso` can build isomorphisms without importing `Data.Isomorphism` directly.

`cabal build`, `cabal test`, and `cabal haddock` all pass.