### PR TITLE
feat: Kindly.Rank2 interface for 1-3 functor parameters

### DIFF
--- a/laws/Kindly/Rank2/Laws.hs
+++ b/laws/Kindly/Rank2/Laws.hs
@@ -1,106 +1,98 @@
--- | @hedgehog-classes@ 'Laws' for the rank-2 (higher-kinded) functor classes in
--- "Kindly.Rank2", whose objects are type constructors and whose morphisms are
--- natural transformations.
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | @hedgehog-classes@ 'Laws' for the rank-2 selectors in "Kindly.Rank2".
 --
--- 'bmapLaws' covers a 'BFunctor' @b@, a 'CategoricalFunctor' whose domain is the
--- functor category @(->) '~>' (->)@, so @'bmap'@ lifts a natural transformation
--- @forall x. f x -> g x@. 'bmap2Laws' covers a 'BFunctor2' @b@, whose morphisms
--- are natural transformations between bifunctors, @forall x x'. p x x' -> p x x'@.
---
--- Hedgehog cannot generate natural transformations, so each bundle is checked at
--- a caller-chosen witness functor with two sample natural endo-transformations
--- to compose, comparing @b f@ values with 'Eq'. This mirrors the fixed sample
--- functions in "Kindly.Functor.Laws".
+-- Each bundle checks identity (@'map1' 'id' = 'id'@) and composition
+-- (@'map1' (n1 '.' n2) = 'map1' n1 '.' 'map1' n2@) for one selector, stated
+-- through the core map and the @Nat@ 'Cat.Category' so the sample morphisms live
+-- in the component category. One bundle per selector therefore covers every
+-- variance. Instantiate at a covariant witness for @d = (->)@, a contravariant
+-- one for @d = 'Data.Functor.Contravariant.Op'@, an invariant one for
+-- @d = 'Data.Isomorphism.Iso' (->)@. Hedgehog cannot generate natural
+-- transformations, so each is checked at a caller-chosen witness with two sample
+-- natural endo-transformations, comparing values with 'Eq'.
 module Kindly.Rank2.Laws
-  ( bmapLaws,
+  ( bmap1Laws,
     bmap2Laws,
+    bmap3Laws,
   )
 where
 
 --------------------------------------------------------------------------------
 
-import Hedgehog (Gen, Property, forAll, property, (===))
+import Control.Category qualified as Cat
+import Hedgehog (Gen, forAll, property, (===))
 import Hedgehog.Classes (Laws (..))
-import Kindly.Rank2 (BFunctor, BFunctor2, bmap, bmap2)
+import Kindly.Class (MapArg1, MapArg2, MapArg3, Nat (..), map1, map2, map3, type (~>))
 import Prelude
 
 --------------------------------------------------------------------------------
--- BFunctor (domain @(->) ~> (->)@)
 
--- | Identity (@'bmap' 'id' = 'id'@) and composition
--- (@'bmap' (n1 . n2) = 'bmap' n1 . 'bmap' n2@) for a 'BFunctor' @b@, checked at a
--- witness functor @f@ (whose @b f@ is 'Eq' and 'Show') using two sample natural
--- endo-transformations @forall x. f x -> f x@.
-bmapLaws ::
-  forall b f.
-  (BFunctor b, Eq (b f), Show (b f)) =>
+bmap1Laws ::
+  forall c d b f.
+  (MapArg1 (c ~> d) b, Cat.Category c, Cat.Category d, Eq (b f), Show (b f)) =>
   Gen (b f) ->
-  (forall x. f x -> f x) ->
-  (forall x. f x -> f x) ->
+  (forall x. d (f x) (f x)) ->
+  (forall x. d (f x) (f x)) ->
   Laws
-bmapLaws genB n1 n2 =
+bmap1Laws genB s1 s2 =
   Laws
-    "BFunctor"
-    [ ("Identity", bmapIdentity genB),
-      ("Composition", bmapComposition genB n1 n2)
+    "bmap1"
+    [ ( "Identity",
+        property $ do
+          bf <- forAll genB
+          map1 (Cat.id :: (c ~> d) f f) bf === bf
+      ),
+      ( "Composition",
+        property $ do
+          bf <- forAll genB
+          map1 (Nat s1 Cat.. Nat s2) bf === map1 (Nat s1) (map1 (Nat s2) bf)
+      )
     ]
 
-bmapIdentity ::
-  forall b f.
-  (BFunctor b, Eq (b f), Show (b f)) =>
-  Gen (b f) ->
-  Property
-bmapIdentity genB = property $ do
-  bf <- forAll genB
-  bmap (\fx -> fx) bf === bf
-
-bmapComposition ::
-  forall b f.
-  (BFunctor b, Eq (b f), Show (b f)) =>
-  Gen (b f) ->
-  (forall x. f x -> f x) ->
-  (forall x. f x -> f x) ->
-  Property
-bmapComposition genB n1 n2 = property $ do
-  bf <- forAll genB
-  bmap (\fx -> n1 (n2 fx)) bf === bmap n1 (bmap n2 bf)
-
---------------------------------------------------------------------------------
--- BFunctor2 (domain @(->) ~> ((->) ~> (->))@)
-
--- | Identity and composition for a 'BFunctor2' @b@, checked at a witness
--- bifunctor @p@ (whose @b p@ is 'Eq' and 'Show') using two sample natural
--- endo-transformations @forall x x'. p x x' -> p x x'@.
 bmap2Laws ::
-  forall b p.
-  (BFunctor2 b, Eq (b p), Show (b p)) =>
-  Gen (b p) ->
-  (forall x x'. p x x' -> p x x') ->
-  (forall x x'. p x x' -> p x x') ->
+  forall c d e b f h.
+  (MapArg2 (c ~> d) e b, Cat.Category c, Cat.Category d, Eq (b f h), Show (b f h)) =>
+  Gen (b f h) ->
+  (forall x. d (f x) (f x)) ->
+  (forall x. d (f x) (f x)) ->
   Laws
-bmap2Laws genB n1 n2 =
+bmap2Laws genB s1 s2 =
   Laws
-    "BFunctor2"
-    [ ("Identity", bmap2Identity genB),
-      ("Composition", bmap2Composition genB n1 n2)
+    "bmap2"
+    [ ( "Identity",
+        property $ do
+          bf <- forAll genB
+          map2 (Cat.id :: (c ~> d) f f) bf === bf
+      ),
+      ( "Composition",
+        property $ do
+          bf <- forAll genB
+          map2 (Nat s1 Cat.. Nat s2) bf === map2 (Nat s1) (map2 (Nat s2) bf)
+      )
     ]
 
-bmap2Identity ::
-  forall b p.
-  (BFunctor2 b, Eq (b p), Show (b p)) =>
-  Gen (b p) ->
-  Property
-bmap2Identity genB = property $ do
-  bp <- forAll genB
-  bmap2 (\px -> px) bp === bp
-
-bmap2Composition ::
-  forall b p.
-  (BFunctor2 b, Eq (b p), Show (b p)) =>
-  Gen (b p) ->
-  (forall x x'. p x x' -> p x x') ->
-  (forall x x'. p x x' -> p x x') ->
-  Property
-bmap2Composition genB n1 n2 = property $ do
-  bp <- forAll genB
-  bmap2 (\px -> n1 (n2 px)) bp === bmap2 n1 (bmap2 n2 bp)
+bmap3Laws ::
+  forall c d e e' b f h i.
+  (MapArg3 (c ~> d) e e' b, Cat.Category c, Cat.Category d, Eq (b f h i), Show (b f h i)) =>
+  Gen (b f h i) ->
+  (forall x. d (f x) (f x)) ->
+  (forall x. d (f x) (f x)) ->
+  Laws
+bmap3Laws genB s1 s2 =
+  Laws
+    "bmap3"
+    [ ( "Identity",
+        property $ do
+          bf <- forAll genB
+          map3 (Cat.id :: (c ~> d) f f) bf === bf
+      ),
+      ( "Composition",
+        property $ do
+          bf <- forAll genB
+          map3 (Nat s1 Cat.. Nat s2) bf === map3 (Nat s1) (map3 (Nat s2) bf)
+      )
+    ]

--- a/src/Kindly/Rank2.hs
+++ b/src/Kindly/Rank2.hs
@@ -38,20 +38,38 @@ import Kindly.Class
 --------------------------------------------------------------------------------
 -- Covariant aliases
 
+-- | A rank-2 type covariant in its single functor parameter.
 type FunctorB b = MapArg1 ((->) ~> (->)) b
 
+-- | A rank-2 type covariant in both functor parameters.
 type BifunctorB b = MapArg2 ((->) ~> (->)) ((->) ~> (->)) b
 
+-- | A rank-2 type covariant in all three functor parameters.
 type TrifunctorB b = MapArg3 ((->) ~> (->)) ((->) ~> (->)) ((->) ~> (->)) b
 
 --------------------------------------------------------------------------------
 -- Selectors
 
 -- | Map the rightmost functor parameter of a rank-2 type.
+--
+-- For a one-parameter HKD:
+--
+-- > data Schema f = Schema (f Int) (f Bool)
+-- >
+-- > instance CategoricalFunctor Schema where
+-- >   type Dom Schema = (->) ~> (->)
+-- >   type Cod Schema = (->)
+-- >   map (Nat nat) (Schema a b) = Schema (nat a) (nat b)
+-- >
+-- > -- turn every field's @Maybe@ into a list
+-- > bmap1 maybeToList :: Schema Maybe -> Schema []
 bmap1 :: (MapArg1 (c ~> d) b) => (forall x. d (f x) (g x)) -> b f -> b g
 bmap1 n = map1 (Nat n)
 
 -- | Map the second-from-right functor parameter of a rank-2 type.
+--
+-- On a two-parameter HKD @b f g@, 'bmap1' maps @g@ (rightmost) and 'bmap2' maps
+-- @f@. Map both by nesting: @bmap2 n1 (bmap1 n2 x)@.
 bmap2 :: (MapArg2 (c ~> d) e b) => (forall x. d (f x) (g x)) -> b f h -> b g h
 bmap2 n = map2 (Nat n)
 
@@ -88,3 +106,35 @@ binvmap2 fwd bwd = bmap2 (Iso fwd bwd)
 -- | Map the third-from-right parameter of a type invariant in it.
 binvmap3 :: (MapArg3 (c ~> Iso (->)) e e' b) => (forall x. f x -> g x) -> (forall x. g x -> f x) -> b f h i -> b g h i
 binvmap3 fwd bwd = bmap3 (Iso fwd bwd)
+
+--------------------------------------------------------------------------------
+-- Mapping several parameters at once
+--
+-- Map several parameters of a concrete rank-2 value by nesting selectors, which
+-- type-checks because the type is known:
+--
+-- > bmap2 n1 (bmap1 n2 x)
+--
+-- There is no polymorphic @bbimap@ \/ @btrimap@ combinator. Every formulation
+-- attempted failed:
+--
+--   * Nesting the selectors inside a polymorphic signature forces GHC to compute
+--     @Dom (b f)@ (a stuck type family) through the @MapArgN@ fundep, and it will
+--     not use the quantified constraint's superclass to unstick it. This is the
+--     GHC < 9.4 quantified-constraint limitation, and it reproduces on 9.10.
+--   * Composing raw @map1@ \/ @map2@ point-free is ambiguous (higher-order
+--     unification of the intermediate); eta-expanded it hits the same stuck @Dom@.
+--   * Routing through @Kindly.Bifunctor.bimap@ would work (a rank-2 HKD is a
+--     bifunctor between functor categories) but its @Bifunctor@ alias pins the
+--     kinds to @Type -> Type -> Type@; a poly-kinded quantified-constraint synonym
+--     is rejected, and the point-free body goes ambiguous at poly-kind anyway.
+--
+-- Nesting already covers this, so the combinator is omitted.
+--
+-- bbimap ::
+--   (MapArg2 (c ~> d) (c' ~> d') b, forall x. MapArg1 (c' ~> d') (b x)) =>
+--   (forall x. d (f x) (g x)) ->
+--   (forall x. d' (h x) (i x)) ->
+--   b f h ->
+--   b g i
+-- bbimap n1 n2 x = bmap2 n1 (bmap1 n2 x)  -- does not compile: stuck Dom (b f)

--- a/src/Kindly/Rank2.hs
+++ b/src/Kindly/Rank2.hs
@@ -16,11 +16,23 @@ module Kindly.Rank2
     bmap1,
     bmap2,
     bmap3,
+
+    -- * Contravariant wrappers
+    bcontramap1,
+    bcontramap2,
+    bcontramap3,
+
+    -- * Invariant wrappers
+    binvmap1,
+    binvmap2,
+    binvmap3,
   )
 where
 
 --------------------------------------------------------------------------------
 
+import Data.Functor.Contravariant (Op (..))
+import Data.Isomorphism (Iso (..))
 import Kindly.Class
 
 --------------------------------------------------------------------------------
@@ -46,3 +58,33 @@ bmap2 n = map2 (Nat n)
 -- | Map the third-from-right functor parameter of a rank-2 type.
 bmap3 :: (MapArg3 (c ~> d) e e' b) => (forall x. d (f x) (g x)) -> b f h i -> b g h i
 bmap3 n = map3 (Nat n)
+
+--------------------------------------------------------------------------------
+-- Contravariant wrappers
+
+-- | Map the rightmost parameter of a type contravariant in it.
+bcontramap1 :: (MapArg1 (c ~> Op) b) => (forall x. g x -> f x) -> b f -> b g
+bcontramap1 n = bmap1 (Op n)
+
+-- | Map the second-from-right parameter of a type contravariant in it.
+bcontramap2 :: (MapArg2 (c ~> Op) e b) => (forall x. g x -> f x) -> b f h -> b g h
+bcontramap2 n = bmap2 (Op n)
+
+-- | Map the third-from-right parameter of a type contravariant in it.
+bcontramap3 :: (MapArg3 (c ~> Op) e e' b) => (forall x. g x -> f x) -> b f h i -> b g h i
+bcontramap3 n = bmap3 (Op n)
+
+--------------------------------------------------------------------------------
+-- Invariant wrappers
+
+-- | Map the rightmost parameter of a type invariant in it, supplying both legs.
+binvmap1 :: (MapArg1 (c ~> Iso (->)) b) => (forall x. f x -> g x) -> (forall x. g x -> f x) -> b f -> b g
+binvmap1 fwd bwd = bmap1 (Iso fwd bwd)
+
+-- | Map the second-from-right parameter of a type invariant in it.
+binvmap2 :: (MapArg2 (c ~> Iso (->)) e b) => (forall x. f x -> g x) -> (forall x. g x -> f x) -> b f h -> b g h
+binvmap2 fwd bwd = bmap2 (Iso fwd bwd)
+
+-- | Map the third-from-right parameter of a type invariant in it.
+binvmap3 :: (MapArg3 (c ~> Iso (->)) e e' b) => (forall x. f x -> g x) -> (forall x. g x -> f x) -> b f h i -> b g h i
+binvmap3 fwd bwd = bmap3 (Iso fwd bwd)

--- a/src/Kindly/Rank2.hs
+++ b/src/Kindly/Rank2.hs
@@ -1,9 +1,21 @@
--- | Work in Progress.
+-- | Rank-2 functors: 'CategoricalFunctor's whose parameters are themselves
+-- functors. A type with @N@ functor parameters is an @N@-ary functor between
+-- functor categories, and 'bmap1' \/ 'bmap2' \/ 'bmap3' select which parameter
+-- to map.
+--
+-- The selectors count parameters __from the right__, matching the core
+-- 'Kindly.Class.map1' \/ 'Kindly.Class.map2' \/ 'Kindly.Class.map3'. On
+-- @b f g h@, 'bmap1' maps @h@, 'bmap2' maps @g@, and 'bmap3' maps @f@.
 module Kindly.Rank2
-  ( BFunctor,
-    bmap,
-    BFunctor2,
+  ( -- * Covariant aliases
+    FunctorB,
+    BifunctorB,
+    TrifunctorB,
+
+    -- * Selectors
+    bmap1,
     bmap2,
+    bmap3,
   )
 where
 
@@ -12,14 +24,25 @@ where
 import Kindly.Class
 
 --------------------------------------------------------------------------------
+-- Covariant aliases
 
-type BFunctor b = FunctorOf ((->) ~> (->)) (->) b
+type FunctorB b = MapArg1 ((->) ~> (->)) b
 
-bmap :: BFunctor b => forall f g. (forall x. f x -> g x) -> b f -> b g 
-bmap nat = map (Nat nat)
+type BifunctorB b = MapArg2 ((->) ~> (->)) ((->) ~> (->)) b
 
-type BFunctor2 b = FunctorOf ((->) ~> (->) ~> (->)) (->) b
+type TrifunctorB b = MapArg3 ((->) ~> (->)) ((->) ~> (->)) ((->) ~> (->)) b
 
-bmap2 :: BFunctor2 b => forall f g. (forall x x'. f x x' -> g x x') -> b f -> b g 
-bmap2 nat = map (Nat (Nat nat))
+--------------------------------------------------------------------------------
+-- Selectors
 
+-- | Map the rightmost functor parameter of a rank-2 type.
+bmap1 :: (MapArg1 (c ~> d) b) => (forall x. d (f x) (g x)) -> b f -> b g
+bmap1 n = map1 (Nat n)
+
+-- | Map the second-from-right functor parameter of a rank-2 type.
+bmap2 :: (MapArg2 (c ~> d) e b) => (forall x. d (f x) (g x)) -> b f h -> b g h
+bmap2 n = map2 (Nat n)
+
+-- | Map the third-from-right functor parameter of a rank-2 type.
+bmap3 :: (MapArg3 (c ~> d) e e' b) => (forall x. d (f x) (g x)) -> b f h i -> b g h i
+bmap3 n = map3 (Nat n)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -97,14 +97,16 @@ exampleSpec = do
     it "works covariantly" $ do
       UUT.trimap show show show (True, False, ()) `shouldBe` ("True", "False", "()")
 
-  describe "bmap" $ do
-    it "works" $ do
+  describe "bmap1" $ do
+    it "maps the rightmost functor" $ do
       let hkd = MyHKD (Just True) Nothing
-      project (UUT.bmap maybeToList hkd) `shouldBe` ([True], [])
+      project (UUT.bmap1 maybeToList hkd) `shouldBe` ([True], [])
 
-  describe "bmap2" $ do
-    it "works" $ do
-      field (UUT.bmap2 (\(a, _) -> Left a) (MyHKD2 ((), True))) `shouldBe` (Left () :: Either () Bool)
+  describe "bmap2 / bmap1 on a two-functor HKD" $ do
+    it "bmap2 hits the first parameter" $ do
+      projeH2a (UUT.bmap2 maybeToList (MyHKD2 (Just True) (Just 1))) `shouldBe` ([True], Just (1 :: Int))
+    it "bmap1 hits the second parameter" $ do
+      projeH2b (UUT.bmap1 maybeToList (MyHKD2 (Just True) (Just 1))) `shouldBe` (Just True, [1 :: Int])
 
 --------------------------------------------------------------------------------
 -- Rank-2 witnesses
@@ -121,11 +123,22 @@ instance UUT.CategoricalFunctor MyHKD where
   map :: (UUT.Nat (->) (->)) f g -> MyHKD f -> MyHKD g
   map (UUT.Nat nat) MyHKD {..} = MyHKD (nat one) (nat two)
 
-newtype MyHKD2 p = MyHKD2 {field :: p () Bool}
+data MyHKD2 f g = MyHKD2 (f Bool) (g Int)
+
+projeH2a :: MyHKD2 [] Maybe -> ([Bool], Maybe Int)
+projeH2a (MyHKD2 a b) = (a, b)
+
+projeH2b :: MyHKD2 Maybe [] -> (Maybe Bool, [Int])
+projeH2b (MyHKD2 a b) = (a, b)
+
+instance UUT.CategoricalFunctor (MyHKD2 f) where
+  type Dom (MyHKD2 f) = (->) UUT.~> (->)
+  type Cod (MyHKD2 f) = (->)
+
+  map (UUT.Nat nat) (MyHKD2 a b) = MyHKD2 a (nat b)
 
 instance UUT.CategoricalFunctor MyHKD2 where
-  type Dom MyHKD2 = (->) UUT.~> ((->) UUT.~> (->))
-  type Cod MyHKD2 = (->)
+  type Dom MyHKD2 = (->) UUT.~> (->)
+  type Cod MyHKD2 = ((->) UUT.~> (->)) UUT.~> (->)
 
-  map :: UUT.Dom MyHKD2 p q -> MyHKD2 p -> MyHKD2 q
-  map (UUT.Nat (UUT.Nat nat)) MyHKD2 {..} = MyHKD2 (nat field)
+  map (UUT.Nat nat) = UUT.Nat (\(MyHKD2 a b) -> MyHKD2 (nat a) b)

--- a/test/Rank2LawsSpec.hs
+++ b/test/Rank2LawsSpec.hs
@@ -9,61 +9,113 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
--- | Self-test for @kindly-functors:laws@' rank-2 (higher-kinded) bundles. Runs
--- 'bmapLaws' and 'bmap2Laws' against witness functors whose natural
--- endo-transformations are non-trivial. They carry lists, so @reverse@ and
--- @drop@ give genuine, composition-distinguishing morphisms.
+-- | Self-test for @kindly-functors:laws@' rank-2 bundles. Runs 'bmap1Laws',
+-- 'bmap2Laws', and 'bmap3Laws' against covariant one-, two-, and three-functor
+-- witnesses, plus a contravariant and an invariant witness, so the reused
+-- bundles exercise every variance. The witnesses carry lists, so @reverse@ and
+-- @drop 1@ give genuine, composition-distinguishing natural transformations.
+-- The contravariant and invariant witnesses hold functions, so they are compared
+-- by observation against fixed probe inputs.
 module Rank2LawsSpec (tests) where
 
 --------------------------------------------------------------------------------
 
+import Data.Functor.Contravariant (Op (..))
+import Data.Isomorphism (Iso (..), embed, project)
 import Data.String (fromString)
 import Hedgehog (Gen, Group (..), Property, PropertyName, checkSequential)
 import Hedgehog.Classes (Laws (..))
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Kindly (CategoricalFunctor (..), Nat (..), type (~>))
-import Kindly.Rank2.Laws (bmap2Laws, bmapLaws)
+import Kindly.Rank2.Laws (bmap1Laws, bmap2Laws, bmap3Laws)
 import Prelude
 
 --------------------------------------------------------------------------------
--- Witness rank-2 functor over @f :: Type -> Type@.
+-- Covariant witnesses (one, two, three functor parameters)
 
-data HKD f = HKD (f Bool) (f Int)
+data H1 f = H1 (f Bool) (f Int)
 
-deriving instance (Eq (f Bool), Eq (f Int)) => Eq (HKD f)
+deriving instance (Eq (f Bool), Eq (f Int)) => Eq (H1 f)
 
-deriving instance (Show (f Bool), Show (f Int)) => Show (HKD f)
+deriving instance (Show (f Bool), Show (f Int)) => Show (H1 f)
 
-instance CategoricalFunctor HKD where
-  type Dom HKD = (->) ~> (->)
-  type Cod HKD = (->)
+instance CategoricalFunctor H1 where
+  type Dom H1 = (->) ~> (->)
+  type Cod H1 = (->)
+  map :: Nat (->) (->) f g -> H1 f -> H1 g
+  map (Nat nat) (H1 a b) = H1 (nat a) (nat b)
 
-  map :: (Nat (->) (->)) f g -> HKD f -> HKD g
-  map (Nat nat) (HKD a b) = HKD (nat a) (nat b)
+data H2 f g = H2 (f Bool) (g Int)
 
--- Witness bifunctor with non-trivial natural endomorphisms.
+deriving instance (Eq (f Bool), Eq (g Int)) => Eq (H2 f g)
 
-data BiList x y = BiList [x] [y]
+deriving instance (Show (f Bool), Show (g Int)) => Show (H2 f g)
 
-deriving instance (Eq x, Eq y) => Eq (BiList x y)
+instance CategoricalFunctor (H2 f) where
+  type Dom (H2 f) = (->) ~> (->)
+  type Cod (H2 f) = (->)
+  map (Nat nat) (H2 a b) = H2 a (nat b)
 
-deriving instance (Show x, Show y) => Show (BiList x y)
+instance CategoricalFunctor H2 where
+  type Dom H2 = (->) ~> (->)
+  type Cod H2 = ((->) ~> (->)) ~> (->)
+  map (Nat nat) = Nat (\(H2 a b) -> H2 (nat a) b)
 
--- Witness rank-2 functor over @p :: Type -> Type -> Type@.
+data H3 f g h = H3 (f Bool) (g Int) (h Bool)
 
-newtype HKD2 p = HKD2 (p Bool Int)
+deriving instance (Eq (f Bool), Eq (g Int), Eq (h Bool)) => Eq (H3 f g h)
 
-deriving instance (Eq (p Bool Int)) => Eq (HKD2 p)
+deriving instance (Show (f Bool), Show (g Int), Show (h Bool)) => Show (H3 f g h)
 
-deriving instance (Show (p Bool Int)) => Show (HKD2 p)
+instance CategoricalFunctor (H3 f g) where
+  type Dom (H3 f g) = (->) ~> (->)
+  type Cod (H3 f g) = (->)
+  map (Nat nat) (H3 a b c) = H3 a b (nat c)
 
-instance CategoricalFunctor HKD2 where
-  type Dom HKD2 = (->) ~> ((->) ~> (->))
-  type Cod HKD2 = (->)
+instance CategoricalFunctor (H3 f) where
+  type Dom (H3 f) = (->) ~> (->)
+  type Cod (H3 f) = ((->) ~> (->)) ~> (->)
+  map (Nat nat) = Nat (\(H3 a b c) -> H3 a (nat b) c)
 
-  map :: Dom HKD2 p q -> HKD2 p -> HKD2 q
-  map (Nat (Nat nat)) (HKD2 p) = HKD2 (nat p)
+instance CategoricalFunctor H3 where
+  type Dom H3 = (->) ~> (->)
+  type Cod H3 = ((->) ~> (->)) ~> ((->) ~> (->)) ~> (->)
+  map (Nat nat) = Nat (Nat (\(H3 a b c) -> H3 (nat a) b c))
+
+--------------------------------------------------------------------------------
+-- Contravariant and invariant witnesses (function-shaped, over lists)
+
+newtype Consumer f = Consumer (f Int -> Int)
+
+instance CategoricalFunctor Consumer where
+  type Dom Consumer = (->) ~> Op
+  type Cod Consumer = (->)
+  map (Nat opnat) (Consumer c) = Consumer (\g -> c (getOp opnat g))
+
+newtype Endo1 f = Endo1 (f Int -> f Int)
+
+instance CategoricalFunctor Endo1 where
+  type Dom Endo1 = (->) ~> Iso (->)
+  type Cod Endo1 = (->)
+  map (Nat iso) (Endo1 h) = Endo1 (\g -> embed iso (h (project iso g)))
+
+-- Observation: compare function-shaped witnesses by running them on probes.
+
+consumerProbes :: [[Int]]
+consumerProbes = [[], [0], [1, 2], [3, 4, 5]]
+
+instance Eq (Consumer []) where
+  Consumer p == Consumer q = fmap p consumerProbes == fmap q consumerProbes
+
+instance Show (Consumer []) where
+  show (Consumer p) = "Consumer " <> show (fmap p consumerProbes)
+
+instance Eq (Endo1 []) where
+  Endo1 p == Endo1 q = fmap p consumerProbes == fmap q consumerProbes
+
+instance Show (Endo1 []) where
+  show (Endo1 p) = "Endo1 " <> show (fmap p consumerProbes)
 
 --------------------------------------------------------------------------------
 -- Generators and sample natural transformations
@@ -74,17 +126,36 @@ genInt = Gen.int (Range.linear (-100) 100)
 genList :: Gen a -> Gen [a]
 genList = Gen.list (Range.linear 0 4)
 
-genHKD :: Gen (HKD [])
-genHKD = HKD <$> genList Gen.bool <*> genList genInt
+genH1 :: Gen (H1 [])
+genH1 = H1 <$> genList Gen.bool <*> genList genInt
 
-genHKD2 :: Gen (HKD2 BiList)
-genHKD2 = (\xs ys -> HKD2 (BiList xs ys)) <$> genList Gen.bool <*> genList genInt
+genH2 :: Gen (H2 [] [])
+genH2 = H2 <$> genList Gen.bool <*> genList genInt
 
-biReverse :: BiList x y -> BiList x y
-biReverse (BiList xs ys) = BiList (reverse xs) (reverse ys)
+genH3 :: Gen (H3 [] [] [])
+genH3 = H3 <$> genList Gen.bool <*> genList genInt <*> genList Gen.bool
 
-biDrop :: BiList x y -> BiList x y
-biDrop (BiList xs ys) = BiList (drop 1 xs) ys
+genConsumer :: Gen (Consumer [])
+genConsumer = Gen.element [Consumer sum, Consumer length, Consumer (sum . drop 1)]
+
+genEndo1 :: Gen (Endo1 [])
+genEndo1 = Gen.element [Endo1 id, Endo1 reverse, Endo1 (drop 1)]
+
+-- Covariant samples: natural transformations @forall x. [x] -> [x]@.
+-- Contravariant samples: the same wrapped in @Op@.
+-- Invariant samples: paired legs in @Iso (->)@.
+
+opReverse :: forall x. Op [x] [x]
+opReverse = Op reverse
+
+opDrop :: forall x. Op [x] [x]
+opDrop = Op (drop 1)
+
+isoReverse :: forall x. Iso (->) [x] [x]
+isoReverse = Iso reverse reverse
+
+isoDrop :: forall x. Iso (->) [x] [x]
+isoDrop = Iso (drop 1) (drop 1)
 
 --------------------------------------------------------------------------------
 
@@ -96,6 +167,12 @@ tests =
   checkSequential $
     Group "Rank-2 functor laws" $
       concat
-        [ labeled "HKD []" (bmapLaws genHKD reverse (drop 1)),
-          labeled "HKD2 BiList" (bmap2Laws genHKD2 biReverse biDrop)
+        [ labeled "H1 [] bmap1" (bmap1Laws genH1 reverse (drop 1)),
+          labeled "H2 [] [] bmap1" (bmap1Laws genH2 reverse (drop 1)),
+          labeled "H2 [] [] bmap2" (bmap2Laws genH2 reverse (drop 1)),
+          labeled "H3 [] [] [] bmap1" (bmap1Laws genH3 reverse (drop 1)),
+          labeled "H3 [] [] [] bmap2" (bmap2Laws genH3 reverse (drop 1)),
+          labeled "H3 [] [] [] bmap3" (bmap3Laws genH3 reverse (drop 1)),
+          labeled "Consumer [] bmap1 (contravariant)" (bmap1Laws genConsumer opReverse opDrop),
+          labeled "Endo1 [] bmap1 (invariant)" (bmap1Laws genEndo1 isoReverse isoDrop)
         ]


### PR DESCRIPTION
Gives `Kindly.Rank2` a real interface for rank-2 (HKD-style) types with one, two, or three functor parameters.

- Selectors `bmap1`/`bmap2`/`bmap3`, polymorphic in the component category. `bmapK` maps the K-th functor parameter from the right, matching the core `map1`/`map2`/`map3`.
- Variance wrappers `bcontramap1`/`2`/`3` and `binvmap1`/`2`/`3`, which wrap `Op`/`Iso` the way `contramap`/`invmap` do in `Kindly.Functor`.
- Covariant aliases `FunctorB`/`BifunctorB`/`TrifunctorB`.
- Law bundles `bmap1Laws`/`bmap2Laws`/`bmap3Laws`, one per selector and `d`-polymorphic, so a single bundle covers covariant, contravariant, and invariant witnesses.

Removes the old `bmap`/`BFunctor` and the bifunctor-kind `bmap2`/`BFunctor2`. That shape is reachable via `bmap1` at `d = (->) ~> (->)`.
