### PR TITLE
feat: Add generic deriving of CategoricalFunctor via kind-generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,15 @@
   Re-export `Iso` from `Kindly.Functor`, `Kindly.Bifunctor`, `Kindly.Trifunctor`,
   and `Kindly` so callers of `mapIso`/`bimapIso`/`trimapIso` can build
   isomorphisms without importing `Data.Isomorphism` directly.
+* Give `CategoricalFunctor`'s `map` a generic default backed by `kind-generics`,
+  so a datatype with a `GenericK` instance (from `deriveGenericK`) gets a
+  `CategoricalFunctor` instance from an empty body carrying only its `Dom` and
+  `Cod`. The default reads variance off the field structure and dispatches on the
+  instance's categories: covariant (`Dom = (->)`), contravariant (`Op`), and
+  invariant (`Iso (->)`) single-parameter functors, and two- and three-parameter
+  functors (bifunctors, profunctors, trifunctors) in any per-argument combination
+  of those variances. A covariant or contravariant instance of the wrong sign is
+  a compile error rather than a wrong answer. Adds a `kind-generics` dependency.
 
 ## 0.1.0.1 -- 2024-02-04
 

--- a/kindly-functors.cabal
+++ b/kindly-functors.cabal
@@ -70,6 +70,8 @@ library
       base > 4 && < 5,
       bifunctors                    >= 5.6 && < 5.7,
       containers                    >= 0.6 && < 0.9,
+      kind-generics                 >= 0.5 && < 0.6,
+      kind-generics-th              >= 0.2.3 && < 0.3,
       mtl                           >= 2.2.2 && < 2.4,
       profunctors                   >= 5.6.2 && < 5.7,
       semigroupoids                 >= 6.0.0 && < 6.1,
@@ -102,7 +104,8 @@ library laws
 test-suite kindly-functors-test
     import:           warnings
     default-language: Haskell2010
-    other-modules:    LawsSpec
+    other-modules:    GenericSpec
+                      LawsSpec
                       Rank2LawsSpec
     type:             exitcode-stdio-1.0
     hs-source-dirs:   test
@@ -114,6 +117,8 @@ test-suite kindly-functors-test
         hspec,
         hedgehog                      >= 1.4 && < 1.6,
         hedgehog-classes              >= 0.2 && < 0.3,
+        kind-generics                 >= 0.5 && < 0.6,
+        kind-generics-th              >= 0.2.3 && < 0.3,
         kindly-functors,
         kindly-functors:laws,
         profunctors                   >= 5.6.2 && < 5.7,

--- a/src/Kindly/Class.hs
+++ b/src/Kindly/Class.hs
@@ -1,6 +1,32 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE KindSignatures #-}
 
-module Kindly.Class where
+module Kindly.Class
+  ( -- * Category-polymorphic functors
+    CategoricalFunctor (..),
+    Cat,
+    FunctorOf,
+
+    -- * Natural transformations
+    Nat (..),
+    runNat,
+    type (~>),
+
+    -- * One-, two-, and three-argument interfaces
+    MapArg1 (..),
+    MapArg2 (..),
+    MapArg3 (..),
+
+    -- * Lifting @(->)@ isomorphisms
+    LiftIso (..),
+
+    -- * Generic deriving
+    GenericK,
+    deriveGenericK,
+  )
+where
 
 --------------------------------------------------------------------------------
 
@@ -17,7 +43,10 @@ import Data.Semigroupoid (Semigroupoid (..))
 -- Earlier GHCs still treat @~@ as built-in syntax and do not export it.
 import Data.Type.Equality (type (~))
 #endif
-import GHC.Base (Monad, Type, pure)
+import Generics.Kind
+import Generics.Kind.TH (deriveGenericK)
+import GHC.Base (Functor (fmap), Monad, Type, pure)
+import Prelude (Bool (..))
 
 --------------------------------------------------------------------------------
 
@@ -38,7 +67,31 @@ class (Category (Dom f), Category (Cod f)) => CategoricalFunctor (f :: from -> t
   type Cod f :: to -> to -> Type
 
   -- | Lift a function of type @Dom f a b@ into a function of type @Cod f (f a) (f b)@.
+  --
+  -- 'map' has a generic default. A datatype with a @kind-generics@ 'GenericK'
+  -- instance (from 'deriveGenericK') gets a 'CategoricalFunctor' instance from an
+  -- empty body that gives only 'Dom' and 'Cod'. The default reads each argument's
+  -- variance off the field structure, so an instance of the wrong sign is a
+  -- compile error rather than a wrong answer.
+  --
+  -- @
+  -- data Pred a = Pred (a -> Bool)
+  -- $(deriveGenericK ''Pred)
+  --
+  -- instance CategoricalFunctor Pred where
+  --   type Dom Pred = Op
+  --   type Cod Pred = (->)
+  -- @
+  --
+  -- This covers covariant (@Dom = (->)@), contravariant (@Op@), and invariant
+  -- (@Iso (->)@) single-argument functors, and bifunctors, profunctors, and
+  -- trifunctors in any per-argument combination of those variances. It does not
+  -- cover non-@(->)@ domains such as @Star Maybe@ (filtering), rank-2 functors,
+  -- constructors carrying constraints or existentials, or a recursive field whose
+  -- head has no base @Functor@.
   map :: Dom f a b -> Cod f (f a) (f b)
+  default map :: (GMapFull (Dom f) (Cod f) f) => Dom f a b -> Cod f (f a) (f b)
+  map = gmapFull
 
 type Cat i = i -> i -> Type
 
@@ -157,3 +210,327 @@ instance (Monad f) => LiftIso (Star f) where
 instance (Monad m) => LiftIso (Kleisli m) where
   liftIso :: Iso (->) a b -> Kleisli m a b
   liftIso i = Kleisli (pure . embed i)
+
+--------------------------------------------------------------------------------
+-- Internals backing map's generic default (see the 'map' Haddock for the
+-- user-facing story). None of the names below are exported. The default
+-- dispatches on the instance's Dom and Cod through GMapFull, which routes to a
+-- position interpreter over the RepK.
+
+-- Covariant interpreter over a RepK, mirroring
+-- @Generics.Kind.Derive.FunctorPosition@ (reproduced to avoid depending on
+-- @kind-generics-deriving@, which pulls in @aeson@).
+class GFunctorPos (f :: LoT k -> Type) (v :: TyVar k Type) (as :: LoT k) (bs :: LoT k) where
+  gfmapp :: (Interpret ('Var v) as -> Interpret ('Var v) bs) -> f as -> f bs
+
+instance GFunctorPos U1 v as bs where
+  gfmapp _ U1 = U1
+
+instance (GFunctorPos f v as bs) => GFunctorPos (M1 i c f) v as bs where
+  gfmapp v (M1 x) = M1 (gfmapp @_ @f @v @as @bs v x)
+
+instance (GFunctorPos f v as bs, GFunctorPos g v as bs) => GFunctorPos (f :+: g) v as bs where
+  gfmapp v (L1 x) = L1 (gfmapp @_ @f @v @as @bs v x)
+  gfmapp v (R1 x) = R1 (gfmapp @_ @g @v @as @bs v x)
+
+instance (GFunctorPos f v as bs, GFunctorPos g v as bs) => GFunctorPos (f :*: g) v as bs where
+  gfmapp v (x :*: y) = gfmapp @_ @f @v @as @bs v x :*: gfmapp @_ @g @v @as @bs v y
+
+instance (GFunctorArgPos t v as bs (ContainsTyVar v t)) => GFunctorPos (Field t) v as bs where
+  gfmapp v (Field x) = Field (gfmappf @_ @t @v @as @bs @(ContainsTyVar v t) v x)
+
+class GFunctorArgPos (t :: Atom d Type) (v :: TyVar d Type) (as :: LoT d) (bs :: LoT d) (p :: Bool) where
+  gfmappf :: (Interpret ('Var v) as -> Interpret ('Var v) bs) -> Interpret t as -> Interpret t bs
+
+instance (Interpret t as ~ Interpret t bs) => GFunctorArgPos t v as bs 'False where
+  gfmappf _ = id
+
+instance
+  ( Functor (Interpret f as),
+    Interpret f as ~ Interpret f bs,
+    GFunctorArgPos x v as bs (ContainsTyVar v x)
+  ) =>
+  GFunctorArgPos (f ':@: x) v as bs 'True
+  where
+  gfmappf f x = fmap (gfmappf @_ @x @v @as @bs @(ContainsTyVar v x) f) x
+
+instance (w ~ v) => GFunctorArgPos ('Var w) v as bs 'True where
+  gfmappf f x = f x
+
+-- Contravariant interpreter. At a function field the domain is mapped by the
+-- covariant interpreter and the codomain recurses contravariantly.
+class GContraPos (f :: LoT k -> Type) (v :: TyVar k Type) (as :: LoT k) (bs :: LoT k) where
+  gcontrap :: (Interpret ('Var v) bs -> Interpret ('Var v) as) -> f as -> f bs
+
+instance GContraPos U1 v as bs where
+  gcontrap _ U1 = U1
+
+instance (GContraPos f v as bs) => GContraPos (M1 i c f) v as bs where
+  gcontrap v (M1 x) = M1 (gcontrap @_ @f @v @as @bs v x)
+
+instance (GContraPos f v as bs, GContraPos g v as bs) => GContraPos (f :+: g) v as bs where
+  gcontrap v (L1 x) = L1 (gcontrap @_ @f @v @as @bs v x)
+  gcontrap v (R1 x) = R1 (gcontrap @_ @g @v @as @bs v x)
+
+instance (GContraPos f v as bs, GContraPos g v as bs) => GContraPos (f :*: g) v as bs where
+  gcontrap v (x :*: y) = gcontrap @_ @f @v @as @bs v x :*: gcontrap @_ @g @v @as @bs v y
+
+instance (GContraArgPos t v as bs (ContainsTyVar v t)) => GContraPos (Field t) v as bs where
+  gcontrap v (Field x) = Field (gcontrapf @_ @t @v @as @bs @(ContainsTyVar v t) v x)
+
+class GContraArgPos (t :: Atom d Type) (v :: TyVar d Type) (as :: LoT d) (bs :: LoT d) (p :: Bool) where
+  gcontrapf :: (Interpret ('Var v) bs -> Interpret ('Var v) as) -> Interpret t as -> Interpret t bs
+
+instance (Interpret t as ~ Interpret t bs) => GContraArgPos t v as bs 'False where
+  gcontrapf _ = id
+
+instance
+  ( GFunctorArgPos dom v bs as (ContainsTyVar v dom),
+    GContraArgPos cod v as bs (ContainsTyVar v cod)
+  ) =>
+  GContraArgPos (('Kon (->) ':@: dom) ':@: cod) v as bs 'True
+  where
+  gcontrapf k field =
+    gcontrapf @_ @cod @v @as @bs @(ContainsTyVar v cod) k
+      . field
+      . gfmappf @_ @dom @v @bs @as @(ContainsTyVar v dom) k
+
+-- Invariant interpreter. Threads both legs of an isomorphism, swapping them at
+-- each function field.
+class GInvPos (f :: LoT k -> Type) (v :: TyVar k Type) (as :: LoT k) (bs :: LoT k) where
+  ginvp ::
+    (Interpret ('Var v) as -> Interpret ('Var v) bs) ->
+    (Interpret ('Var v) bs -> Interpret ('Var v) as) ->
+    f as ->
+    f bs
+
+instance GInvPos U1 v as bs where
+  ginvp _ _ U1 = U1
+
+instance (GInvPos f v as bs) => GInvPos (M1 i c f) v as bs where
+  ginvp fwd bwd (M1 x) = M1 (ginvp @_ @f @v @as @bs fwd bwd x)
+
+instance (GInvPos f v as bs, GInvPos g v as bs) => GInvPos (f :+: g) v as bs where
+  ginvp fwd bwd (L1 x) = L1 (ginvp @_ @f @v @as @bs fwd bwd x)
+  ginvp fwd bwd (R1 x) = R1 (ginvp @_ @g @v @as @bs fwd bwd x)
+
+instance (GInvPos f v as bs, GInvPos g v as bs) => GInvPos (f :*: g) v as bs where
+  ginvp fwd bwd (x :*: y) = ginvp @_ @f @v @as @bs fwd bwd x :*: ginvp @_ @g @v @as @bs fwd bwd y
+
+instance (GInvArgPos t v as bs (ContainsTyVar v t)) => GInvPos (Field t) v as bs where
+  ginvp fwd bwd (Field x) = Field (ginvpf @_ @t @v @as @bs @(ContainsTyVar v t) fwd bwd x)
+
+class GInvArgPos (t :: Atom d Type) (v :: TyVar d Type) (as :: LoT d) (bs :: LoT d) (p :: Bool) where
+  ginvpf ::
+    (Interpret ('Var v) as -> Interpret ('Var v) bs) ->
+    (Interpret ('Var v) bs -> Interpret ('Var v) as) ->
+    Interpret t as ->
+    Interpret t bs
+
+instance (Interpret t as ~ Interpret t bs) => GInvArgPos t v as bs 'False where
+  ginvpf _ _ = id
+
+instance (w ~ v) => GInvArgPos ('Var w) v as bs 'True where
+  ginvpf fwd _ x = fwd x
+
+instance
+  ( GInvArgPos dom v bs as (ContainsTyVar v dom),
+    GInvArgPos cod v as bs (ContainsTyVar v cod)
+  ) =>
+  GInvArgPos (('Kon (->) ':@: dom) ':@: cod) v as bs 'True
+  where
+  ginvpf fwd bwd field =
+    ginvpf @_ @cod @v @as @bs @(ContainsTyVar v cod) fwd bwd
+      . field
+      . ginvpf @_ @dom @v @bs @as @(ContainsTyVar v dom) bwd fwd
+
+instance
+  {-# OVERLAPPABLE #-}
+  ( Functor (Interpret f as),
+    Interpret f as ~ Interpret f bs,
+    GInvArgPos x v as bs (ContainsTyVar v x)
+  ) =>
+  GInvArgPos (f ':@: x) v as bs 'True
+  where
+  ginvpf fwd bwd x = fmap (ginvpf @_ @x @v @as @bs @(ContainsTyVar v x) fwd bwd) x
+
+--------------------------------------------------------------------------------
+-- The wrappers quantify the assignment internally so a plain
+-- @G...K (RepK f)@ suffices as a constraint.
+
+class GFunctorK (rep :: LoT (Type -> Type) -> Type) where
+  gfmapK :: (a -> b) -> rep (LoT1 a) -> rep (LoT1 b)
+
+instance (forall a b. GFunctorPos rep 'VZ (LoT1 a) (LoT1 b)) => GFunctorK rep where
+  gfmapK :: forall a b. (a -> b) -> rep (LoT1 a) -> rep (LoT1 b)
+  gfmapK = gfmapp @_ @rep @'VZ @(LoT1 a) @(LoT1 b)
+
+class GContraK (rep :: LoT (Type -> Type) -> Type) where
+  gcontraK :: (b -> a) -> rep (LoT1 a) -> rep (LoT1 b)
+
+instance (forall a b. GContraPos rep 'VZ (LoT1 a) (LoT1 b)) => GContraK rep where
+  gcontraK :: forall a b. (b -> a) -> rep (LoT1 a) -> rep (LoT1 b)
+  gcontraK = gcontrap @_ @rep @'VZ @(LoT1 a) @(LoT1 b)
+
+class GInvK (rep :: LoT (Type -> Type) -> Type) where
+  ginvK :: (a -> b) -> (b -> a) -> rep (LoT1 a) -> rep (LoT1 b)
+
+instance (forall a b. GInvPos rep 'VZ (LoT1 a) (LoT1 b)) => GInvK rep where
+  ginvK :: forall a b. (a -> b) -> (b -> a) -> rep (LoT1 a) -> rep (LoT1 b)
+  ginvK = ginvp @_ @rep @'VZ @(LoT1 a) @(LoT1 b)
+
+class GBiFirstK (rep :: LoT (Type -> Type -> Type) -> Type) where
+  gbiFirstK :: (a -> c) -> rep (LoT2 a n) -> rep (LoT2 c n)
+
+instance (forall a c n. GFunctorPos rep 'VZ (LoT2 a n) (LoT2 c n)) => GBiFirstK rep where
+  gbiFirstK :: forall a c n. (a -> c) -> rep (LoT2 a n) -> rep (LoT2 c n)
+  gbiFirstK = gfmapp @_ @rep @'VZ @(LoT2 a n) @(LoT2 c n)
+
+class GProFirstK (rep :: LoT (Type -> Type -> Type) -> Type) where
+  gproFirstK :: (c -> a) -> rep (LoT2 a n) -> rep (LoT2 c n)
+
+instance (forall a c n. GContraPos rep 'VZ (LoT2 a n) (LoT2 c n)) => GProFirstK rep where
+  gproFirstK :: forall a c n. (c -> a) -> rep (LoT2 a n) -> rep (LoT2 c n)
+  gproFirstK = gcontrap @_ @rep @'VZ @(LoT2 a n) @(LoT2 c n)
+
+class GBiFirstInvK (rep :: LoT (Type -> Type -> Type) -> Type) where
+  gbiFirstInvK :: (a -> c) -> (c -> a) -> rep (LoT2 a n) -> rep (LoT2 c n)
+
+instance (forall a c n. GInvPos rep 'VZ (LoT2 a n) (LoT2 c n)) => GBiFirstInvK rep where
+  gbiFirstInvK :: forall a c n. (a -> c) -> (c -> a) -> rep (LoT2 a n) -> rep (LoT2 c n)
+  gbiFirstInvK = ginvp @_ @rep @'VZ @(LoT2 a n) @(LoT2 c n)
+
+type LoT3 a b c = a :&&: b :&&: c :&&: LoT0
+
+class GTriFirstK (rep :: LoT (Type -> Type -> Type -> Type) -> Type) where
+  gtriFirstK :: (a -> b) -> rep (LoT3 a x y) -> rep (LoT3 b x y)
+
+instance (forall a b x y. GFunctorPos rep 'VZ (LoT3 a x y) (LoT3 b x y)) => GTriFirstK rep where
+  gtriFirstK :: forall a b x y. (a -> b) -> rep (LoT3 a x y) -> rep (LoT3 b x y)
+  gtriFirstK = gfmapp @_ @rep @'VZ @(LoT3 a x y) @(LoT3 b x y)
+
+class GTriProFirstK (rep :: LoT (Type -> Type -> Type -> Type) -> Type) where
+  gtriProFirstK :: (b -> a) -> rep (LoT3 a x y) -> rep (LoT3 b x y)
+
+instance (forall a b x y. GContraPos rep 'VZ (LoT3 a x y) (LoT3 b x y)) => GTriProFirstK rep where
+  gtriProFirstK :: forall a b x y. (b -> a) -> rep (LoT3 a x y) -> rep (LoT3 b x y)
+  gtriProFirstK = gcontrap @_ @rep @'VZ @(LoT3 a x y) @(LoT3 b x y)
+
+class GTriInvFirstK (rep :: LoT (Type -> Type -> Type -> Type) -> Type) where
+  gtriInvFirstK :: (a -> b) -> (b -> a) -> rep (LoT3 a x y) -> rep (LoT3 b x y)
+
+instance (forall a b x y. GInvPos rep 'VZ (LoT3 a x y) (LoT3 b x y)) => GTriInvFirstK rep where
+  gtriInvFirstK :: forall a b x y. (a -> b) -> (b -> a) -> rep (LoT3 a x y) -> rep (LoT3 b x y)
+  gtriInvFirstK = ginvp @_ @rep @'VZ @(LoT3 a x y) @(LoT3 b x y)
+
+--------------------------------------------------------------------------------
+-- One dispatch class keyed on the domain and codomain categories, so the single
+-- 'map' default covers every variance and arity below.
+
+class GMapFull (dom :: from -> from -> Type) (cod :: to -> to -> Type) (f :: from -> to) where
+  gmapFull :: dom a b -> cod (f a) (f b)
+
+-- covariant, single parameter (also the last argument of a two-parameter type)
+instance
+  (GenericK f, GFunctorK (RepK f)) =>
+  GMapFull ((->) :: Type -> Type -> Type) ((->) :: Type -> Type -> Type) (f :: Type -> Type)
+  where
+  gmapFull :: forall a b. (a -> b) -> f a -> f b
+  gmapFull d = toK @_ @f @(LoT1 b) . gfmapK @(RepK f) d . fromK @_ @f @(LoT1 a)
+
+-- contravariant, single parameter
+instance
+  (GenericK f, GContraK (RepK f)) =>
+  GMapFull (Op :: Type -> Type -> Type) ((->) :: Type -> Type -> Type) (f :: Type -> Type)
+  where
+  gmapFull :: forall a b. Op a b -> f a -> f b
+  gmapFull (Op k) = toK @_ @f @(LoT1 b) . gcontraK @(RepK f) k . fromK @_ @f @(LoT1 a)
+
+-- invariant, single parameter
+instance
+  (GenericK f, GInvK (RepK f)) =>
+  GMapFull (Iso (->) :: Type -> Type -> Type) ((->) :: Type -> Type -> Type) (f :: Type -> Type)
+  where
+  gmapFull :: forall a b. Iso (->) a b -> f a -> f b
+  gmapFull i = toK @_ @f @(LoT1 b) . ginvK @(RepK f) (embed i) (project i) . fromK @_ @f @(LoT1 a)
+
+-- covariant in the first of two arguments, producing a Nat. The second
+-- argument's category @cat2@ is the phantom source of the Nat and does not
+-- affect the mapping, so a single instance covers every second-argument
+-- variance.
+instance
+  (GenericK f, GBiFirstK (RepK f)) =>
+  GMapFull ((->) :: Type -> Type -> Type) (cat2 ~> (->)) (f :: Type -> Type -> Type)
+  where
+  gmapFull :: forall a c. (a -> c) -> Nat cat2 (->) (f a) (f c)
+  gmapFull h = Nat go
+    where
+      go :: forall n. f a n -> f c n
+      go = toK @_ @f @(LoT2 c n) . gbiFirstK @(RepK f) h . fromK @_ @f @(LoT2 a n)
+
+-- contravariant in the first of two arguments (a profunctor when the second is
+-- covariant), producing a Nat.
+instance
+  (GenericK f, GProFirstK (RepK f)) =>
+  GMapFull (Op :: Type -> Type -> Type) (cat2 ~> (->)) (f :: Type -> Type -> Type)
+  where
+  gmapFull :: forall a c. Op a c -> Nat cat2 (->) (f a) (f c)
+  gmapFull (Op k) = Nat go
+    where
+      go :: forall n. f a n -> f c n
+      go = toK @_ @f @(LoT2 c n) . gproFirstK @(RepK f) k . fromK @_ @f @(LoT2 a n)
+
+-- invariant in the first of two arguments, producing a Nat.
+instance
+  (GenericK f, GBiFirstInvK (RepK f)) =>
+  GMapFull (Iso (->) :: Type -> Type -> Type) (cat2 ~> (->)) (f :: Type -> Type -> Type)
+  where
+  gmapFull :: forall a c. Iso (->) a c -> Nat cat2 (->) (f a) (f c)
+  gmapFull i = Nat go
+    where
+      go :: forall n. f a n -> f c n
+      go = toK @_ @f @(LoT2 c n) . gbiFirstInvK @(RepK f) (embed i) (project i) . fromK @_ @f @(LoT2 a n)
+
+-- covariant in the first of three arguments, producing a nested Nat. As with
+-- two arguments, the trailing categories are phantom sources and one instance
+-- per first-argument variance covers every combination of the other two.
+instance
+  (GenericK f, GTriFirstK (RepK f)) =>
+  GMapFull ((->) :: Type -> Type -> Type) (cat2 ~> cat3 ~> (->)) (f :: Type -> Type -> Type -> Type)
+  where
+  gmapFull :: forall a b. (a -> b) -> Nat cat2 (cat3 ~> (->)) (f a) (f b)
+  gmapFull morph = Nat middle
+    where
+      middle :: forall x. Nat cat3 (->) (f a x) (f b x)
+      middle = Nat inner
+        where
+          inner :: forall y. f a x y -> f b x y
+          inner = toK @_ @f @(LoT3 b x y) . gtriFirstK @(RepK f) morph . fromK @_ @f @(LoT3 a x y)
+
+-- contravariant in the first of three arguments.
+instance
+  (GenericK f, GTriProFirstK (RepK f)) =>
+  GMapFull (Op :: Type -> Type -> Type) (cat2 ~> cat3 ~> (->)) (f :: Type -> Type -> Type -> Type)
+  where
+  gmapFull :: forall a b. Op a b -> Nat cat2 (cat3 ~> (->)) (f a) (f b)
+  gmapFull (Op k) = Nat middle
+    where
+      middle :: forall x. Nat cat3 (->) (f a x) (f b x)
+      middle = Nat inner
+        where
+          inner :: forall y. f a x y -> f b x y
+          inner = toK @_ @f @(LoT3 b x y) . gtriProFirstK @(RepK f) k . fromK @_ @f @(LoT3 a x y)
+
+-- invariant in the first of three arguments.
+instance
+  (GenericK f, GTriInvFirstK (RepK f)) =>
+  GMapFull (Iso (->) :: Type -> Type -> Type) (cat2 ~> cat3 ~> (->)) (f :: Type -> Type -> Type -> Type)
+  where
+  gmapFull :: forall a b. Iso (->) a b -> Nat cat2 (cat3 ~> (->)) (f a) (f b)
+  gmapFull i = Nat middle
+    where
+      middle :: forall x. Nat cat3 (->) (f a x) (f b x)
+      middle = Nat inner
+        where
+          inner :: forall y. f a x y -> f b x y
+          inner = toK @_ @f @(LoT3 b x y) . gtriInvFirstK @(RepK f) (embed i) (project i) . fromK @_ @f @(LoT3 a x y)

--- a/test/GenericSpec.hs
+++ b/test/GenericSpec.hs
@@ -1,0 +1,381 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Law-checks 'CategoricalFunctor' instances that use the generic @map@
+-- default. Every instance below has an empty body, only its 'Dom' and 'Cod'.
+module GenericSpec (tests) where
+
+--------------------------------------------------------------------------------
+
+import Data.Functor.Contravariant (Op (..))
+import Data.String (fromString)
+import Generics.Kind.TH (deriveGenericK)
+import Hedgehog (Gen, Group (..), Property, PropertyName, checkSequential, forAll, property, (===))
+import Hedgehog.Classes (Laws (..))
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Kindly (CategoricalFunctor (..), Iso (..), map1, map2, map3, type (~>))
+import Kindly.Functor qualified as K
+import Kindly.Functor.Laws (bifunctorLaws, contravariantFunctorLaws, functorLaws, invariantFunctorLaws, observedBifunctorLaws, observedTrifunctorLaws, profunctorLaws)
+import Prelude
+
+--------------------------------------------------------------------------------
+
+genInt :: Gen Int
+genInt = Gen.int (Range.linear (-100) 100)
+
+-- Covariant product.
+data Pair a = Pair a a
+  deriving (Eq, Show)
+
+$(deriveGenericK ''Pair)
+
+instance CategoricalFunctor Pair where
+  type Dom Pair = (->)
+  type Cod Pair = (->)
+
+genPair :: Gen a -> Gen (Pair a)
+genPair g = Pair <$> g <*> g
+
+-- Covariant nested container.
+newtype Wrap a = Wrap [a]
+  deriving (Eq, Show)
+
+$(deriveGenericK ''Wrap)
+
+instance CategoricalFunctor Wrap where
+  type Dom Wrap = (->)
+  type Cod Wrap = (->)
+
+genWrap :: Gen a -> Gen (Wrap a)
+genWrap g = Wrap <$> Gen.list (Range.linear 0 4) g
+
+-- Contravariant: the parameter to the left of an arrow.
+newtype Pred' a = Pred' (a -> Bool)
+
+$(deriveGenericK ''Pred')
+
+instance CategoricalFunctor Pred' where
+  type Dom Pred' = Op
+  type Cod Pred' = (->)
+
+genPred' :: Gen (Pred' Int)
+genPred' = (\n -> Pred' (> n)) <$> genInt
+
+obsPred' :: Pred' Int -> Int -> Bool
+obsPred' (Pred' p) = p
+
+-- Covariant with the parameter to the right of an arrow.
+data Box a = Box a (Int -> a)
+
+$(deriveGenericK ''Box)
+
+instance CategoricalFunctor Box where
+  type Dom Box = (->)
+  type Cod Box = (->)
+
+boxArrowCodomain :: Property
+boxArrowCodomain = property $ do
+  n <- forAll genInt
+  let Box v f = K.fmap (show :: Int -> String) (Box n (\i -> i + n))
+  v === show n
+  f 3 === show (3 + n)
+
+-- Invariant: the parameter on both sides of an arrow.
+newtype Endo' a = Endo' (a -> a)
+
+$(deriveGenericK ''Endo')
+
+instance CategoricalFunctor Endo' where
+  type Dom Endo' = Iso (->)
+  type Cod Endo' = (->)
+
+genEndo' :: Gen (Endo' Int)
+genEndo' = (\n -> Endo' (+ n)) <$> genInt
+
+obsEndo' :: Endo' Int -> Int -> Int
+obsEndo' (Endo' f) = f
+
+-- Invariant with mixed occurrences: contravariant in the arrow, covariant in
+-- the list.
+data Mix a = Mix (a -> Bool) [a]
+
+$(deriveGenericK ''Mix)
+
+instance CategoricalFunctor Mix where
+  type Dom Mix = Iso (->)
+  type Cod Mix = (->)
+
+genMix :: Gen (Mix Int)
+genMix = Mix <$> ((\n -> (> n)) <$> genInt) <*> Gen.list (Range.linear 0 4) genInt
+
+obsMix :: Mix Int -> Int -> (Bool, [Int])
+obsMix (Mix p xs) a = (p a, xs)
+
+-- Covariant bifunctor.
+data BiT a b = BiT a b
+  deriving (Eq, Show)
+
+$(deriveGenericK ''BiT)
+
+instance CategoricalFunctor (BiT a) where
+  type Dom (BiT a) = (->)
+  type Cod (BiT a) = (->)
+
+instance CategoricalFunctor BiT where
+  type Dom BiT = (->)
+  type Cod BiT = (->) ~> (->)
+
+genBiT :: Gen a -> Gen b -> Gen (BiT a b)
+genBiT ga gb = BiT <$> ga <*> gb
+
+-- Profunctor: contravariant in the first argument, covariant in the second.
+data ProT a b = ProT (a -> b)
+
+$(deriveGenericK ''ProT)
+
+instance CategoricalFunctor (ProT a) where
+  type Dom (ProT a) = (->)
+  type Cod (ProT a) = (->)
+
+instance CategoricalFunctor ProT where
+  type Dom ProT = Op
+  type Cod ProT = (->) ~> (->)
+
+genProT :: Gen (ProT Int Int)
+genProT = (\n -> ProT (+ n)) <$> genInt
+
+obsProT :: ProT Int Int -> Int -> Int
+obsProT (ProT f) = f
+
+-- Covariant first, contravariant second (a `Bifunctor (->) Op`).
+data CovCon a b = CovCon a (b -> Int)
+
+$(deriveGenericK ''CovCon)
+
+instance CategoricalFunctor (CovCon a) where
+  type Dom (CovCon a) = Op
+  type Cod (CovCon a) = (->)
+
+instance CategoricalFunctor CovCon where
+  type Dom CovCon = (->)
+  type Cod CovCon = Op ~> (->)
+
+genCovCon :: Gen (CovCon Int Int)
+genCovCon = CovCon <$> genInt <*> ((\n b -> b * 2 + n) <$> genInt)
+
+obsCovCon :: CovCon Int Int -> Int -> (Int, Int)
+obsCovCon (CovCon a f) x = (a, f x)
+
+-- Contravariant in both arguments (an Op/Op bifunctor).
+data ConCon a b = ConCon (a -> Int) (b -> Int)
+
+$(deriveGenericK ''ConCon)
+
+instance CategoricalFunctor (ConCon a) where
+  type Dom (ConCon a) = Op
+  type Cod (ConCon a) = (->)
+
+instance CategoricalFunctor ConCon where
+  type Dom ConCon = Op
+  type Cod ConCon = Op ~> (->)
+
+conConProp :: Property
+conConProp = property $ do
+  n <- forAll genInt
+  let ConCon f1 g1 = map2 (Op ((+ 1) :: Int -> Int)) (ConCon (* 2) (+ n))
+  f1 3 === (3 + 1) * 2
+  g1 5 === 5 + n
+  let ConCon f2 g2 = map1 (Op ((+ 3) :: Int -> Int)) (ConCon (* 2) (+ n))
+  f2 3 === 3 * 2
+  g2 5 === (5 + 3) + n
+
+-- Invariant first, covariant second.
+data InvCov a b = InvCov (a -> a) b
+
+$(deriveGenericK ''InvCov)
+
+instance CategoricalFunctor (InvCov a) where
+  type Dom (InvCov a) = (->)
+  type Cod (InvCov a) = (->)
+
+instance CategoricalFunctor InvCov where
+  type Dom InvCov = Iso (->)
+  type Cod InvCov = (->) ~> (->)
+
+invCovProp :: Property
+invCovProp = property $ do
+  n <- forAll genInt
+  let InvCov g1 b1 = map2 (Iso (+ (1 :: Int)) (subtract 1)) (InvCov (* 2) n)
+  g1 3 === ((3 - 1) * 2) + 1
+  b1 === n
+  let InvCov g2 b2 = map1 ((+ 10) :: Int -> Int) (InvCov ((* 2) :: Int -> Int) n)
+  g2 4 === 4 * 2
+  b2 === n + 10
+
+-- Covariant trifunctor. map3 hits the first argument, map2 the second (through
+-- the bifunctor partial application), map1 the third.
+data Tri a b c = Tri a b c
+  deriving (Eq, Show)
+
+$(deriveGenericK ''Tri)
+
+instance CategoricalFunctor (Tri a b) where
+  type Dom (Tri a b) = (->)
+  type Cod (Tri a b) = (->)
+
+instance CategoricalFunctor (Tri a) where
+  type Dom (Tri a) = (->)
+  type Cod (Tri a) = (->) ~> (->)
+
+instance CategoricalFunctor Tri where
+  type Dom Tri = (->)
+  type Cod Tri = (->) ~> (->) ~> (->)
+
+genTriBi :: Gen a -> Gen b -> Gen (Tri Int a b)
+genTriBi ga gb = Tri <$> genInt <*> ga <*> gb
+
+obsTri :: Tri Int Int Int -> Int -> (Int, Int, Int)
+obsTri (Tri a b c) _ = (a, b, c)
+
+-- Contravariant-first trifunctor, exercising the nested-Nat contravariant path.
+data TriC a b c = TriC (a -> Int) b c
+
+$(deriveGenericK ''TriC)
+
+instance CategoricalFunctor (TriC a b) where
+  type Dom (TriC a b) = (->)
+  type Cod (TriC a b) = (->)
+
+instance CategoricalFunctor (TriC a) where
+  type Dom (TriC a) = (->)
+  type Cod (TriC a) = (->) ~> (->)
+
+instance CategoricalFunctor TriC where
+  type Dom TriC = Op
+  type Cod TriC = (->) ~> (->) ~> (->)
+
+triCProp :: Property
+triCProp = property $ do
+  n <- forAll genInt
+  let TriC f b c = map3 (Op ((+ 1) :: Int -> Int)) (TriC (* 2) n (n + 1))
+  f 3 === (3 + 1) * 2
+  b === n
+  c === n + 1
+
+-- Sum types with a nullary constructor, one per variance, to exercise the
+-- interpreters' @:+:@ and @U1@ cases.
+
+data Sum3 a = S3None | S3One a | S3Two a a
+  deriving (Eq, Show)
+
+$(deriveGenericK ''Sum3)
+
+instance CategoricalFunctor Sum3 where
+  type Dom Sum3 = (->)
+  type Cod Sum3 = (->)
+
+genSum3 :: Gen a -> Gen (Sum3 a)
+genSum3 g = Gen.choice [pure S3None, S3One <$> g, S3Two <$> g <*> g]
+
+data ConSum a = CSNone | CSOne (a -> Bool) | CSTwo (a -> Int) (a -> Bool)
+
+$(deriveGenericK ''ConSum)
+
+instance CategoricalFunctor ConSum where
+  type Dom ConSum = Op
+  type Cod ConSum = (->)
+
+genConSum :: Gen (ConSum Int)
+genConSum = Gen.choice [pure CSNone, (\n -> CSOne (> n)) <$> genInt, (\n -> CSTwo (+ n) (> n)) <$> genInt]
+
+obsConSum :: ConSum Int -> Int -> (Bool, Int, Bool)
+obsConSum CSNone _ = (False, 0, False)
+obsConSum (CSOne p) x = (p x, 0, False)
+obsConSum (CSTwo f p) x = (False, f x, p x)
+
+data InvSum a = ISNone | ISOne (a -> a)
+
+$(deriveGenericK ''InvSum)
+
+instance CategoricalFunctor InvSum where
+  type Dom InvSum = Iso (->)
+  type Cod InvSum = (->)
+
+genInvSum :: Gen (InvSum Int)
+genInvSum = Gen.choice [pure ISNone, (\n -> ISOne (+ n)) <$> genInt]
+
+obsInvSum :: InvSum Int -> Int -> Int
+obsInvSum ISNone x = x
+obsInvSum (ISOne f) x = f x
+
+-- Invariant-first trifunctor.
+data TriI a b c = TriI (a -> a) b c
+
+$(deriveGenericK ''TriI)
+
+instance CategoricalFunctor (TriI a b) where
+  type Dom (TriI a b) = (->)
+  type Cod (TriI a b) = (->)
+
+instance CategoricalFunctor (TriI a) where
+  type Dom (TriI a) = (->)
+  type Cod (TriI a) = (->) ~> (->)
+
+instance CategoricalFunctor TriI where
+  type Dom TriI = Iso (->)
+  type Cod TriI = (->) ~> (->) ~> (->)
+
+triIProp :: Property
+triIProp = property $ do
+  n <- forAll genInt
+  let TriI f b c = map3 (Iso (+ (1 :: Int)) (subtract 1)) (TriI (* 2) n (n + 1))
+  f 3 === ((3 - 1) * 2) + 1
+  b === n
+  c === n + 1
+
+--------------------------------------------------------------------------------
+
+labeled :: String -> Laws -> [(PropertyName, Property)]
+labeled prefix ls = [(fromString (prefix <> " " <> n), p) | (n, p) <- lawsProperties ls]
+
+tests :: IO Bool
+tests =
+  checkSequential $
+    Group "Generic deriving" $
+      concat
+        [ labeled "Pair (product)" (functorLaws genPair),
+          labeled "Wrap [] (nested)" (functorLaws genWrap),
+          labeled "Pred' (a -> Bool)" (contravariantFunctorLaws genPred' obsPred'),
+          labeled "Endo' (a -> a)" (invariantFunctorLaws genEndo' obsEndo'),
+          labeled "Mix (a -> Bool, [a])" (invariantFunctorLaws genMix obsMix),
+          labeled "BiT (bifunctor, map2)" (bifunctorLaws genBiT),
+          labeled "BiT Int (bifunctor, map1)" (functorLaws (genBiT genInt)),
+          labeled "ProT (profunctor, map2)" (profunctorLaws genProT obsProT),
+          labeled "CovCon ((->)/Op bifunctor, map2)" (observedBifunctorLaws genCovCon obsCovCon),
+          labeled "CovCon Int (contravariant second)" (contravariantFunctorLaws genCovCon obsCovCon),
+          labeled "Tri (trifunctor, map3)" (observedTrifunctorLaws (genTriBi genInt genInt) obsTri),
+          labeled "Tri Int (trifunctor, map2)" (bifunctorLaws genTriBi),
+          labeled "Tri Int Int (trifunctor, map1)" (functorLaws (genTriBi genInt)),
+          labeled "Sum3 (covariant sum + nullary)" (functorLaws genSum3),
+          labeled "ConSum (contravariant sum + nullary)" (contravariantFunctorLaws genConSum obsConSum),
+          labeled "InvSum (invariant sum + nullary)" (invariantFunctorLaws genInvSum obsInvSum)
+        ]
+        ++ [ (fromString "Box (Int -> a) covariant arrow codomain", boxArrowCodomain),
+             (fromString "ConCon (Op/Op bifunctor)", conConProp),
+             (fromString "InvCov (invariant/covariant bifunctor)", invCovProp),
+             (fromString "TriC (contravariant-first trifunctor)", triCProp),
+             (fromString "TriI (invariant-first trifunctor)", triIProp)
+           ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,6 +17,7 @@ import Data.Isomorphism (Iso (Iso))
 import Data.Maybe (maybeToList)
 import Data.Monoid (Endo (..))
 import Data.Profunctor (Star (..))
+import GenericSpec qualified
 import Kindly qualified as UUT
 import LawsSpec qualified
 import Rank2LawsSpec qualified
@@ -31,7 +32,8 @@ main = do
   summary <- hspecWithResult defaultConfig exampleSpec
   lawsOk <- LawsSpec.tests
   rank2Ok <- Rank2LawsSpec.tests
-  when (summaryFailures summary > 0 || not lawsOk || not rank2Ok) exitFailure
+  genOk <- GenericSpec.tests
+  when (summaryFailures summary > 0 || not lawsOk || not rank2Ok || not genOk) exitFailure
 
 --------------------------------------------------------------------------------
 -- Example-based (characterization) tests


### PR DESCRIPTION
Partially resolves #7.

Gives `CategoricalFunctor`'s `map` a generic default backed by `kind-generics`. A datatype with a `GenericK` instance (from `deriveGenericK`) gets a `CategoricalFunctor` instance from an empty body carrying only its `Dom` and `Cod`.

## Usage

```haskell
data Pred a = Pred (a -> Bool)
$(deriveGenericK ''Pred)

instance CategoricalFunctor Pred where
  type Dom Pred = Op
  type Cod Pred = (->)
  -- map is defaulted
```

The same empty body derives a covariant, contravariant, or invariant functor, or a bifunctor/profunctor, according to `Dom`/`Cod`:

```haskell
instance CategoricalFunctor (P a) where { type Dom (P a) = (->); type Cod (P a) = (->) }
instance CategoricalFunctor P     where { type Dom P = (->);     type Cod P = (->) ~> (->) }
```

## How it works

The default dispatches through a single class `GMapFull (Dom f) (Cod f) f` keyed on the domain and codomain categories, which routes to a position interpreter over the `RepK`. Variance is read off the field structure, so a covariant or contravariant instance of the wrong sign is a compile error, not a wrong answer. The interpreter reproduces the variance logic itself rather than depending on `kind-generics-deriving` (whose `Json` module drags in `aeson`). Because the default only fires for instances that omit `map`, the library's existing hand-written instances are unaffected.

## Scope

Covers covariant, contravariant, and invariant single-parameter functors, and covariant bifunctors and profunctors at two parameters. Not covered: `Filterable` (`Star Maybe`) and other non-`(->)` domain categories (not structural), trifunctors, and the remaining two-parameter variance combinations.

## Dependency

The library gains a `kind-generics` dependency (which pulls only `first-class-families` and `kind-apply` transitively). An earlier iteration isolated this in an opt-in sublibrary, but the class default is far more ergonomic (empty instances) and the dependency is light, so it now lives in the main library.

## Tests

`test/GenericSpec.hs` law-checks empty-body instances across a covariant product, a covariant nested container, a covariant function codomain, a contravariant function domain, two invariant types (`a -> a` and a mixed `(a -> Bool, [a])`), a covariant bifunctor (both arguments), and a profunctor.
