### PR TITLE
Add hlint to format workflow and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: hlint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up HLint
+        uses: haskell-actions/hlint-setup@v2
+        with:
+          version: "3.10"
+
+      - name: Run HLint
+        run: hlint src/ laws/ test/

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,8 @@
+# HLint configuration for kindly-functors.
+
+# This library constructs the functor/bifunctor hierarchy from scratch, so the
+# explicit tuple maps (\(a, c) -> (f a, c)) are intentional. Data.Bifunctor's
+# first/second are the abstractions these modules generalize, and hlint flags
+# the rewrites as increasing laziness.
+- ignore: {name: Use first}
+- ignore: {name: Use second}

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
               cabal-install
               haskell.compiler.${compiler}
               haskell.packages.${compiler}.haskell-language-server
+              hlint
               just
               nixpkgs-fmt
               ormolu

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ set shell := ["bash", "-uc"]
 
 ormolu := "ormolu"
 nix_fmt := "nixpkgs-fmt"
+hlint := "hlint"
 shellcheck := "shellcheck --external-sources --source-path=SCRIPTDIR"
 
 # List available recipes
@@ -62,17 +63,33 @@ check-format-nix:
       echo "{{nix_fmt}} is not installed; skipping"
     fi
 
-# auto-format all Haskell and Nix source
-format: format-hs format-nix
+# auto-format all Haskell and Nix source, then lint Haskell with hlint
+format: format-hs format-nix lint-hs
 
-# auto-format changed Haskell source and all Nix source
-format-changed: format-hs-changed format-nix
+# auto-format changed Haskell source and all Nix source, then lint changed Haskell
+format-changed: format-hs-changed format-nix lint-hs-changed
 
 # check all Haskell and Nix formatting
 check-format: check-format-hs check-format-nix
 
 # check changed Haskell formatting and all Nix formatting
 check-format-changed: check-format-hs-changed check-format-nix
+
+# lint Haskell source code using hlint
+lint-hs:
+    @echo "running {{hlint}}"
+    @{{hlint}} $(git ls-files '*.hs')
+
+# lint changed Haskell source code using hlint
+lint-hs-changed:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    base=$(git merge-base HEAD origin/main)
+    changed=$(git diff --diff-filter=d --name-only "$base" | grep -E '\.hs$' || true)
+    if [ -n "$changed" ]; then
+      echo "running {{hlint}}"
+      {{hlint}} $changed
+    fi
 
 # lint shell scripts using shellcheck
 lint-shell:

--- a/kindly-functors.cabal
+++ b/kindly-functors.cabal
@@ -41,6 +41,7 @@ common common-extensions
     GeneralizedNewtypeDeriving
     ImportQualifiedPost
     InstanceSigs
+    LambdaCase
     MultiParamTypeClasses
     NoImplicitPrelude
     PolyKinds

--- a/src/Kindly/Bifunctor.hs
+++ b/src/Kindly/Bifunctor.hs
@@ -167,7 +167,7 @@ instance (MapArg2 (->) (->) p, MapArg2 (->) (->) q) => CategoricalFunctor (Sum p
 
   map f =
     Nat
-      ( \s -> case s of
+      ( \case
           L2 pab -> L2 (map2 f pab)
           R2 qab -> R2 (map2 f qab)
       )
@@ -254,7 +254,7 @@ instance (MapArg2 Op (->) q) => CategoricalFunctor (Hask.Rift p q :: Type -> Typ
   type Dom (Hask.Rift p q) = Op
   type Cod (Hask.Rift p q) = (->) ~> (->)
 
-  map (Op f) = Nat (\(Hask.Rift g) -> Hask.Rift (\p -> map2 (Op f) (g p)))
+  map (Op f) = Nat (\(Hask.Rift g) -> Hask.Rift (map2 (Op f) . g))
 
 instance CategoricalFunctor (Hask.Yoneda p) where
   type Dom (Hask.Yoneda p) = Op
@@ -296,7 +296,7 @@ instance CategoricalFunctor (Hask.Copastro p) where
   type Dom (Hask.Copastro p) = Op
   type Cod (Hask.Copastro p) = (->) ~> (->)
 
-  map (Op f) = Nat (\(Hask.Copastro g) -> Hask.Copastro (\n -> Hask.lmap f (g n)))
+  map (Op f) = Nat (\(Hask.Copastro g) -> Hask.Copastro (Hask.lmap f . g))
 
 instance (MapArg2 Op (->) p) => CategoricalFunctor (Hask.TambaraSum p) where
   type Dom (Hask.TambaraSum p) = Op
@@ -320,7 +320,7 @@ instance CategoricalFunctor (Hask.CopastroSum p) where
   type Dom (Hask.CopastroSum p) = Op
   type Cod (Hask.CopastroSum p) = (->) ~> (->)
 
-  map (Op f) = Nat (\(Hask.CopastroSum g) -> Hask.CopastroSum (\n -> Hask.lmap f (g n)))
+  map (Op f) = Nat (\(Hask.CopastroSum g) -> Hask.CopastroSum (Hask.lmap f . g))
 
 instance (MapArg2 Op (->) p) => CategoricalFunctor (Hask.Closure p) where
   type Dom (Hask.Closure p) = Op

--- a/src/Kindly/Class.hs
+++ b/src/Kindly/Class.hs
@@ -43,9 +43,9 @@ import Data.Semigroupoid (Semigroupoid (..))
 -- Earlier GHCs still treat @~@ as built-in syntax and do not export it.
 import Data.Type.Equality (type (~))
 #endif
+import GHC.Base (Functor (fmap), Monad, Type, pure)
 import Generics.Kind
 import Generics.Kind.TH (deriveGenericK)
-import GHC.Base (Functor (fmap), Monad, Type, pure)
 import Prelude (Bool (..))
 
 --------------------------------------------------------------------------------
@@ -76,6 +76,7 @@ class (Category (Dom f), Category (Cod f)) => CategoricalFunctor (f :: from -> t
   --
   -- @
   -- data Pred a = Pred (a -> Bool)
+
   -- $(deriveGenericK ''Pred)
   --
   -- instance CategoricalFunctor Pred where
@@ -89,6 +90,7 @@ class (Category (Dom f), Category (Cod f)) => CategoricalFunctor (f :: from -> t
   -- cover non-@(->)@ domains such as @Star Maybe@ (filtering), rank-2 functors,
   -- constructors carrying constraints or existentials, or a recursive field whose
   -- head has no base @Functor@.
+
   map :: Dom f a b -> Cod f (f a) (f b)
   default map :: (GMapFull (Dom f) (Cod f) f) => Dom f a b -> Cod f (f a) (f b)
   map = gmapFull
@@ -252,10 +254,10 @@ instance
   ) =>
   GFunctorArgPos (f ':@: x) v as bs 'True
   where
-  gfmappf f x = fmap (gfmappf @_ @x @v @as @bs @(ContainsTyVar v x) f) x
+  gfmappf f = fmap (gfmappf @_ @x @v @as @bs @(ContainsTyVar v x) f)
 
 instance (w ~ v) => GFunctorArgPos ('Var w) v as bs 'True where
-  gfmappf f x = f x
+  gfmappf f = f
 
 -- Contravariant interpreter. At a function field the domain is mapped by the
 -- covariant interpreter and the codomain recurses contravariantly.
@@ -331,7 +333,7 @@ instance (Interpret t as ~ Interpret t bs) => GInvArgPos t v as bs 'False where
   ginvpf _ _ = id
 
 instance (w ~ v) => GInvArgPos ('Var w) v as bs 'True where
-  ginvpf fwd _ x = fwd x
+  ginvpf fwd _ = fwd
 
 instance
   ( GInvArgPos dom v bs as (ContainsTyVar v dom),
@@ -352,7 +354,7 @@ instance
   ) =>
   GInvArgPos (f ':@: x) v as bs 'True
   where
-  ginvpf fwd bwd x = fmap (ginvpf @_ @x @v @as @bs @(ContainsTyVar v x) fwd bwd) x
+  ginvpf fwd bwd = fmap (ginvpf @_ @x @v @as @bs @(ContainsTyVar v x) fwd bwd)
 
 --------------------------------------------------------------------------------
 -- The wrappers quantify the assignment internally so a plain

--- a/src/Kindly/Functor.hs
+++ b/src/Kindly/Functor.hs
@@ -617,7 +617,7 @@ instance (forall x. MapArg1 (->) (p x)) => CategoricalFunctor (Hask.Profunctor.T
   type Cod (Hask.Profunctor.TambaraSum p a) = (->)
 
   map f (Hask.Profunctor.TambaraSum t) =
-    Hask.Profunctor.TambaraSum $ map1 (\e -> case e of Left b -> Left (f b); Right c -> Right c) t
+    Hask.Profunctor.TambaraSum $ map1 (\case Left b -> Left (f b); Right c -> Right c) t
 
 instance CategoricalFunctor (Hask.Profunctor.PastroSum p a) where
   type Dom (Hask.Profunctor.PastroSum p a) = (->)

--- a/test/GenericSpec.hs
+++ b/test/GenericSpec.hs
@@ -89,7 +89,7 @@ instance CategoricalFunctor Box where
 boxArrowCodomain :: Property
 boxArrowCodomain = property $ do
   n <- forAll genInt
-  let Box v f = K.fmap (show :: Int -> String) (Box n (\i -> i + n))
+  let Box v f = K.fmap (show :: Int -> String) (Box n (+ n))
   v === show n
   f 3 === show (3 + n)
 
@@ -119,7 +119,7 @@ instance CategoricalFunctor Mix where
   type Cod Mix = (->)
 
 genMix :: Gen (Mix Int)
-genMix = Mix <$> ((\n -> (> n)) <$> genInt) <*> Gen.list (Range.linear 0 4) genInt
+genMix = Mix . (\n -> (> n)) <$> genInt <*> Gen.list (Range.linear 0 4) genInt
 
 obsMix :: Mix Int -> Int -> (Bool, [Int])
 obsMix (Mix p xs) a = (p a, xs)
@@ -142,7 +142,7 @@ genBiT :: Gen a -> Gen b -> Gen (BiT a b)
 genBiT ga gb = BiT <$> ga <*> gb
 
 -- Profunctor: contravariant in the first argument, covariant in the second.
-data ProT a b = ProT (a -> b)
+newtype ProT a b = ProT (a -> b)
 
 $(deriveGenericK ''ProT)
 

--- a/test/LawsSpec.hs
+++ b/test/LawsSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeOperators #-}
 
 -- | Self-test for the @kindly-functors:laws@ sublibrary. Runs the exported
@@ -296,7 +297,7 @@ obsTambara :: Tambara (->) Int Int -> Int -> Int
 obsTambara (Tambara t) a = fst (t (a, ()))
 
 genPastro :: Gen (Pastro (->) Int Int)
-genPastro = (\n k -> Pastro (\(y, z) -> y + z) (* n) (\a -> (a, k))) <$> genInt <*> genInt
+genPastro = (\n k -> Pastro (uncurry (+)) (* n) (,k)) <$> genInt <*> genInt
 
 obsPastro :: Pastro (->) Int Int -> Int -> Int
 obsPastro (Pastro l m r) a = case r a of (x, z) -> l (m x, z)
@@ -478,7 +479,7 @@ tests =
           labeled "mapIso Predicate" (mapIsoLaws genPredicate obsPredicate),
           labeled "mapIso Endo" (mapIsoLaws genEndo obsEndo),
           -- bimapIso: isomorphism mapping through a bifunctor's positions.
-          labeled "bimapIso (,)" (bimapIsoLaws (genPairT genInt genInt) (\p _ -> p)),
+          labeled "bimapIso (,)" (bimapIsoLaws (genPairT genInt genInt) const),
           labeled "bimapIso Op" (bimapIsoLaws genOp obsOp),
           labeled "bimapIso Dual (->)" (bimapIsoLaws genDual obsDual),
           -- trimapIso: isomorphism mapping through a trifunctor's positions.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -49,7 +49,7 @@ exampleSpec = do
       (UUT.fmap . UUT.fmap) show (Just (Just True)) `shouldBe` Just (Just "True")
       UUT.fmap ((\f -> f "True") . getPredicate) ((UUT.fmap . UUT.fmap) (Op read) (Just (Predicate not))) `shouldBe` Just False
     it "works over a constrained instance (Kleisli)" $ do
-      runKleisli (UUT.fmap show (Kleisli (\x -> Identity x))) (5 :: Int) `shouldBe` Identity "5"
+      runKleisli (UUT.fmap show (Kleisli Identity)) (5 :: Int) `shouldBe` Identity "5"
 
   describe "invmap" $ do
     it "works invariantly (Endo)" $ do

--- a/test/Rank2LawsSpec.hs
+++ b/test/Rank2LawsSpec.hs
@@ -91,14 +91,14 @@ newtype Consumer f = Consumer (f Int -> Int)
 instance CategoricalFunctor Consumer where
   type Dom Consumer = (->) ~> Op
   type Cod Consumer = (->)
-  map (Nat opnat) (Consumer c) = Consumer (\g -> c (getOp opnat g))
+  map (Nat opnat) (Consumer c) = Consumer (c . getOp opnat)
 
 newtype Endo1 f = Endo1 (f Int -> f Int)
 
 instance CategoricalFunctor Endo1 where
   type Dom Endo1 = (->) ~> Iso (->)
   type Cod Endo1 = (->)
-  map (Nat iso) (Endo1 h) = Endo1 (\g -> embed iso (h (project iso g)))
+  map (Nat iso) (Endo1 h) = Endo1 (embed iso . h . project iso)
 
 -- Observation: compare function-shaped witnesses by running them on probes.
 


### PR DESCRIPTION
Adds hlint linting to the format workflow and CI, and resolves every hint it currently reports.

## Tooling
- `just format` and `just format-changed` now run hlint after the formatters, via new `lint-hs` / `lint-hs-changed` recipes (mirroring the existing `lint-shell` pattern). `just format` exits non-zero if hlint finds anything, since the linter runs last.
- New `.github/workflows/lint.yml` runs `hlint src/ laws/ test/` on push to main and on every PR. It's a standalone job (`haskell-actions/hlint-setup`, pinned to 3.10), so it doesn't run across the GHC matrix.
- `hlint` added to the flake devShell.

## Hints
Started at 25 hints, now zero.
- Fixed 15 genuine hints: eta-reductions in `Class.hs`, lambda-to-composition in `Bifunctor.hs`, and assorted cleanups in the tests (uncurry, const, section, newtype, functor-law fusion).
- Applied 3 extension-gated rewrites: two `\case` sites (enabled `LambdaCase` in the cabal `common-extensions`) and one tuple-section in `LawsSpec.hs` (per-file `TupleSections` pragma, since the test suite doesn't share the common block).
- `.hlint.yaml` ignores `Use first` / `Use second`. Those point at `Data.Bifunctor`, the abstraction these modules build from scratch, and hlint flags the rewrites as increasing laziness.

## Verification
Build clean, 37/37 tests pass, `hlint` reports no hints, formatting clean.